### PR TITLE
Déplacement des responsabilités du contrôleur vers de repo

### DIFF
--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -167,21 +167,13 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     {
         $id = (int) $arguments['typeId'];
         try {
-            $resource = $this->repository->getOne($id);
-            $this->repository->deleteOne($resource);
-            $code = 200;
-            $data = [
-                'code' => $code,
-                'status' => 'success',
-                'message' => '',
-                'data' => '',
-            ];
-
-            return $response->withJson($data, $code);
-        } catch (\DomainException $e) {
+            $this->repository->deleteOne($id);
+        } catch (UnknownResourceException $e) {
             return $this->getResponseNotFound($response, 'Element « type#' . $id . ' » is not a valid resource');
         } catch (\Exception $e) {
-            throw $e;
+            return $this->getResponseError($response, $e);
         }
+        
+        return $this->getResponseSuccess($response, '', 200);
     }
 }

--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -3,6 +3,7 @@ namespace LibertAPI\Absence\Type;
 
 use LibertAPI\Tools\Interfaces;
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Exceptions\UnknownResourceException;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
 
@@ -145,16 +146,9 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
 
         $id = (int) $arguments['typeId'];
         try {
-            $resource = $this->repository->getOne($id);
-        } catch (\DomainException $e) {
+            $this->repository->putOne($id, $body);
+        } catch (UnknownResourceException $e) {
             return $this->getResponseNotFound($response, 'Element « type#' . $id . ' » is not a valid resource');
-        } catch (\Exception $e) {
-            return $this->getResponseError($response, $e);
-        }
-
-        try {
-            $resource->populate($body);
-            $this->repository->putOne($resource);
         } catch (MissingArgumentException $e) {
             return $this->getResponseMissingArgument($response);
         } catch (\DomainException $e) {

--- a/Absence/Type/TypeController.php
+++ b/Absence/Type/TypeController.php
@@ -115,7 +115,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         }
 
         try {
-            $typeId = $this->repository->postOne($body, new TypeEntite([]));
+            $typeId = $this->repository->postOne($body);
         } catch (MissingArgumentException $e) {
             return $this->getResponseMissingArgument($response);
         } catch (\DomainException $e) {

--- a/Groupe/Employe/EmployeRepository.php
+++ b/Groupe/Employe/EmployeRepository.php
@@ -91,7 +91,7 @@ class EmployeRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AEntite $entite) : int
+    public function postOne(array $data) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Groupe/Employe/EmployeRepository.php
+++ b/Groupe/Employe/EmployeRepository.php
@@ -99,7 +99,7 @@ class EmployeRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(AEntite $entite)
+    public function putOne(int $id, array $data)
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Groupe/Employe/EmployeRepository.php
+++ b/Groupe/Employe/EmployeRepository.php
@@ -131,7 +131,7 @@ class EmployeRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AEntite $entite) : int
+    public function deleteOne(int $id) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Groupe/GrandResponsable/GrandResponsableRepository.php
+++ b/Groupe/GrandResponsable/GrandResponsableRepository.php
@@ -100,7 +100,7 @@ class GrandResponsableRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(AEntite $entite)
+    public function putOne(int $id, array $data)
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Groupe/GrandResponsable/GrandResponsableRepository.php
+++ b/Groupe/GrandResponsable/GrandResponsableRepository.php
@@ -92,7 +92,7 @@ class GrandResponsableRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AEntite $entite) : int
+    public function postOne(array $data) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Groupe/GrandResponsable/GrandResponsableRepository.php
+++ b/Groupe/GrandResponsable/GrandResponsableRepository.php
@@ -132,7 +132,7 @@ class GrandResponsableRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AEntite $entite) : int
+    public function deleteOne(int $id) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Groupe/GroupeController.php
+++ b/Groupe/GroupeController.php
@@ -2,6 +2,7 @@
 namespace LibertAPI\Groupe;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Exceptions\UnknownResourceException;
 use LibertAPI\Tools\Interfaces;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
@@ -154,16 +155,9 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
 
         $id = (int) $arguments['groupeId'];
         try {
-            $groupe = $this->repository->getOne($id);
-        } catch (\DomainException $e) {
+            $this->repository->putOne($id, $body);
+        } catch (UnknownResourceException $e) {
             return $this->getResponseNotFound($response, '« #' . $id . ' » is not a valid resource');
-        } catch (\Exception $e) {
-            return $this->getResponseError($response, $e);
-        }
-
-        try {
-            $groupe->populate($body);
-            $this->repository->putOne($groupe);
         } catch (MissingArgumentException $e) {
             return $this->getResponseMissingArgument($response);
         } catch (\DomainException $e) {

--- a/Groupe/GroupeController.php
+++ b/Groupe/GroupeController.php
@@ -176,9 +176,8 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     {
         $id = (int) $arguments['groupeId'];
         try {
-            $groupe = $this->repository->getOne($id);
-            $this->repository->deleteOne($groupe);
-        } catch (\DomainException $e) {
+            $this->repository->deleteOne($id);
+        } catch (UnknownResourceException $e) {
             return $this->getResponseNotFound($response, '« #' . $id . ' » is not a valid resource');
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);

--- a/Groupe/GroupeController.php
+++ b/Groupe/GroupeController.php
@@ -124,7 +124,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         }
 
         try {
-            $groupeId = $this->repository->postOne($body, new GroupeEntite([]));
+            $groupeId = $this->repository->postOne($body);
         } catch (MissingArgumentException $e) {
             return $this->getResponseMissingArgument($response);
         } catch (\DomainException $e) {

--- a/Groupe/Responsable/ResponsableRepository.php
+++ b/Groupe/Responsable/ResponsableRepository.php
@@ -92,7 +92,7 @@ class ResponsableRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AEntite $entite) : int
+    public function postOne(array $data) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Groupe/Responsable/ResponsableRepository.php
+++ b/Groupe/Responsable/ResponsableRepository.php
@@ -100,7 +100,7 @@ class ResponsableRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(AEntite $entite)
+    public function putOne(int $id, array $data)
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Groupe/Responsable/ResponsableRepository.php
+++ b/Groupe/Responsable/ResponsableRepository.php
@@ -132,7 +132,7 @@ class ResponsableRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AEntite $entite) : int
+    public function deleteOne(int $id) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/JourFerie/JourFerieRepository.php
+++ b/JourFerie/JourFerieRepository.php
@@ -54,7 +54,7 @@ class JourFerieRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AEntite $entite) : int
+    public function postOne(array $data) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/JourFerie/JourFerieRepository.php
+++ b/JourFerie/JourFerieRepository.php
@@ -62,7 +62,7 @@ class JourFerieRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(AEntite $entite)
+    public function putOne(int $id, array $data)
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/JourFerie/JourFerieRepository.php
+++ b/JourFerie/JourFerieRepository.php
@@ -96,7 +96,7 @@ class JourFerieRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AEntite $entite) : int
+    public function deleteOne(int $id) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Journal/JournalRepository.php
+++ b/Journal/JournalRepository.php
@@ -55,7 +55,7 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function postOne(array $data, AEntite $entite) : int
+    public function postOne(array $data) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Journal/JournalRepository.php
+++ b/Journal/JournalRepository.php
@@ -95,7 +95,7 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AEntite $entite) : int
+    public function deleteOne(int $id) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Journal/JournalRepository.php
+++ b/Journal/JournalRepository.php
@@ -63,7 +63,7 @@ class JournalRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function putOne(AEntite $entite)
+    public function putOne(int $id, array $data)
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Planning/Creneau/CreneauController.php
+++ b/Planning/Creneau/CreneauController.php
@@ -124,7 +124,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
         $planningId = (int) $arguments['planningId'];
 
         try {
-            $creneauxIds = $this->repository->postList($body, new CreneauEntite([]));
+            $creneauxIds = $this->repository->postList($body);
             $dataMessage = [];
             foreach ($creneauxIds as $id) {
                 $dataMessage[] = $this->router->pathFor('getPlanningCreneauDetail', [

--- a/Planning/Creneau/CreneauController.php
+++ b/Planning/Creneau/CreneauController.php
@@ -2,6 +2,7 @@
 namespace LibertAPI\Planning\Creneau;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Exceptions\UnknownResourceException;
 use LibertAPI\Tools\Interfaces;
 
 use Psr\Http\Message\ServerRequestInterface as IRequest;
@@ -159,16 +160,9 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable
 
         $id = (int) $arguments['creneauId'];
         try {
-            $creneau = $this->repository->getOne($id);
-        } catch (\DomainException $e) {
+            $this->repository->putOne($id, $body);
+        } catch (\UnknownResourceException $e) {
             return $this->getResponseNotFound($response, 'Element « creneau#' . $id . ' » is not a valid resource');
-        } catch (\Exception $e) {
-            return $this->getResponseError($response, $e);
-        }
-
-        try {
-            $creneau->populate($body);
-            $this->repository->putOne($creneau);
         } catch (MissingArgumentException $e) {
             return $this->getResponseMissingArgument($response);
         } catch (\DomainException $e) {

--- a/Planning/Creneau/CreneauRepository.php
+++ b/Planning/Creneau/CreneauRepository.php
@@ -157,7 +157,7 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
     /**
      * @inheritDoc
      */
-    public function deleteOne(AEntite $entite) : int
+    public function deleteOne(int $id) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Planning/Creneau/CreneauRepository.php
+++ b/Planning/Creneau/CreneauRepository.php
@@ -66,14 +66,13 @@ class CreneauRepository extends \LibertAPI\Tools\Libraries\ARepository
      * @throws MissingArgumentException Si un élément requis n'est pas présent
      * @throws \DomainException Si un élément de la ressource n'est pas dans le bon domaine de définition
      */
-    public function postList(array $data, AEntite $entite) : array
+    public function postList(array $data) : array
     {
         $postIds = [];
         $this->beginTransaction();
         foreach ($data as $creneau) {
             try {
-                $cloneEntite = clone $entite;
-                $postIds[] = $this->postOne($creneau, $cloneEntite);
+                $postIds[] = $this->postOne($creneau);
             } catch (\Exception $e) {
                 $this->rollback();
                 throw $e;

--- a/Planning/PlanningController.php
+++ b/Planning/PlanningController.php
@@ -126,7 +126,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         }
 
         try {
-            $planningId = $this->repository->postOne($body, new PlanningEntite([]));
+            $planningId = $this->repository->postOne($body);
         } catch (MissingArgumentException $e) {
             return $this->getResponseMissingArgument($response);
         } catch (\DomainException $e) {

--- a/Planning/PlanningController.php
+++ b/Planning/PlanningController.php
@@ -2,6 +2,7 @@
 namespace LibertAPI\Planning;
 
 use LibertAPI\Tools\Exceptions\MissingArgumentException;
+use LibertAPI\Tools\Exceptions\UnknownResourceException;
 use LibertAPI\Tools\Interfaces;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
@@ -155,17 +156,11 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
         }
 
         $id = (int) $arguments['planningId'];
-        try {
-            $planning = $this->repository->getOne($id);
-        } catch (\DomainException $e) {
-            return $this->getResponseNotFound($response, 'Element « planning#' . $id . ' » is not a valid resource');
-        } catch (\Exception $e) {
-            return $this->getResponseError($response, $e);
-        }
 
         try {
-            $planning->populate($body);
-            $this->repository->putOne($planning);
+            $this->repository->putOne($id, $body);
+        } catch (UnknownResourceException $e) {
+            return $this->getResponseNotFound($response, 'Element « planning#' . $id . ' » is not a valid resource');
         } catch (MissingArgumentException $e) {
             return $this->getResponseMissingArgument($response);
         } catch (\DomainException $e) {

--- a/Planning/PlanningController.php
+++ b/Planning/PlanningController.php
@@ -179,9 +179,8 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
     {
         $id = (int) $arguments['planningId'];
         try {
-            $planning = $this->repository->getOne($id);
-            $this->repository->deleteOne($planning);
-        } catch (\DomainException $e) {
+            $this->repository->deleteOne($id);
+        } catch (UnknownResourceException $e) {
             return $this->getResponseNotFound($response, 'Element « planning#' . $id . ' » is not a valid resource');
         } catch (\Exception $e) {
             return $this->getResponseError($response, $e);

--- a/Tests/Units/Absence/Type/TypeController.php
+++ b/Tests/Units/Absence/Type/TypeController.php
@@ -2,6 +2,7 @@
 namespace LibertAPI\Tests\Units\Absence\Type;
 
 use Psr\Http\Message\ResponseInterface as IResponse;
+use \LibertAPI\Tools\Exceptions\UnknownResourceException;
 
 /**
  * Classe de test du contrôleur des type d'absence
@@ -163,8 +164,8 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
     public function testPutNotFound()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = function () {
-            throw new \DomainException('');
+        $this->repository->getMockController()->putOne = function () {
+            throw new UnknownResourceException('');
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
@@ -173,27 +174,11 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
     }
 
     /**
-     * Teste le fallback de la méthode getOne du put
-     */
-    public function testPutGetOneFallback()
-    {
-        $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = function () {
-            throw new \LogicException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-
-        $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);
-        $this->assertError($response);
-    }
-
-    /**
      * Teste la méthode put avec un argument de body manquant
      */
     public function testPutMissingRequiredArg()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
 
         $this->repository->getMockController()->putOne = function () {
             throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
@@ -210,7 +195,6 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
     public function testPutBadDomain()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \DomainException('');
         };
@@ -226,7 +210,6 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
     public function testPutPutOneFallback()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \LogicException('');
         };
@@ -242,7 +225,6 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
     public function testPutOk()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = '';
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->put($this->request, $this->response, ['typeId' => 99]);

--- a/Tests/Units/Absence/Type/TypeController.php
+++ b/Tests/Units/Absence/Type/TypeController.php
@@ -258,8 +258,8 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
      */
     public function testDeleteNotFound()
     {
-        $this->repository->getMockController()->getOne = function () {
-            throw new \DomainException('');
+        $this->repository->getMockController()->deleteOne = function () {
+            throw new UnknownResourceException('');
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
@@ -272,14 +272,13 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
      */
     public function testDeleteFallback()
     {
-        $this->repository->getMockController()->getOne = function () {
+        $this->repository->getMockController()->deleteOne = function () {
             throw new \LogicException('');
         };
-
-        $this->exception(function () {
-            $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-            $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
-        })->isInstanceOf('\Exception');
+        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
+        
+        $response = $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
+        $this->assertError($response);
     }
 
     /**
@@ -287,7 +286,6 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
      */
     public function testDeleteOk()
     {
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->calling($this->repository)->deleteOne = 34;
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
         $response = $this->testedInstance->delete($this->request, $this->response, ['typeId' => 99]);
@@ -297,7 +295,7 @@ final class TypeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARestC
         $this->array($data)
             ->integer['code']->isIdenticalTo(200)
             ->string['status']->isIdenticalTo('success')
-            ->string['message']->isIdenticalTo('')
+            ->string['message']->isIdenticalTo('OK')
             ->array['data']->isNotEmpty()
         ;
     }

--- a/Tests/Units/Absence/Type/TypeRepository.php
+++ b/Tests/Units/Absence/Type/TypeRepository.php
@@ -18,6 +18,16 @@ final class TypeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepos
             'ta_type' => 81,
             'ta_libelle' => 'libelle',
             'ta_short_libelle' => 'li',
+            'type' => 1,
+        ];
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+            'type' => '1',
+            'libelle' => 'Romeo',
+            'libelleCourt' => 'Juliette',
         ];
     }
 }

--- a/Tests/Units/Groupe/Employe/EmployeRepository.php
+++ b/Tests/Units/Groupe/Employe/EmployeRepository.php
@@ -60,7 +60,7 @@ final class EmployeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->putOne(1, []);
         })->isInstanceOf(\RuntimeException::class);
     }
 

--- a/Tests/Units/Groupe/Employe/EmployeRepository.php
+++ b/Tests/Units/Groupe/Employe/EmployeRepository.php
@@ -51,7 +51,7 @@ final class EmployeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->postOne([], new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->postOne($this->getConsumerContent());
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -62,6 +62,12 @@ final class EmployeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->exception(function () {
             $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
         })->isInstanceOf(\RuntimeException::class);
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+        ];
     }
 
     public function testDeleteOne()

--- a/Tests/Units/Groupe/Employe/EmployeRepository.php
+++ b/Tests/Units/Groupe/Employe/EmployeRepository.php
@@ -75,7 +75,7 @@ final class EmployeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->deleteOne(91823);
         })->isInstanceOf(\RuntimeException::class);
     }
 }

--- a/Tests/Units/Groupe/GrandResponsable/GrandResponsableRepository.php
+++ b/Tests/Units/Groupe/GrandResponsable/GrandResponsableRepository.php
@@ -60,7 +60,7 @@ final class GrandResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libr
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->putOne(123, []);
         })->isInstanceOf(\RuntimeException::class);
     }
 

--- a/Tests/Units/Groupe/GrandResponsable/GrandResponsableRepository.php
+++ b/Tests/Units/Groupe/GrandResponsable/GrandResponsableRepository.php
@@ -51,7 +51,7 @@ final class GrandResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libr
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->postOne([], new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->postOne($this->getConsumerContent());
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -62,6 +62,12 @@ final class GrandResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libr
         $this->exception(function () {
             $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
         })->isInstanceOf(\RuntimeException::class);
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+        ];
     }
 
     public function testDeleteOne()

--- a/Tests/Units/Groupe/GrandResponsable/GrandResponsableRepository.php
+++ b/Tests/Units/Groupe/GrandResponsable/GrandResponsableRepository.php
@@ -75,7 +75,7 @@ final class GrandResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libr
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->deleteOne(2182);
         })->isInstanceOf(\RuntimeException::class);
     }
 }

--- a/Tests/Units/Groupe/GroupeController.php
+++ b/Tests/Units/Groupe/GroupeController.php
@@ -2,6 +2,7 @@
 namespace LibertAPI\Tests\Units\Groupe;
 
 use Psr\Http\Message\ResponseInterface as IResponse;
+use LibertAPI\Tools\Exceptions\UnknownResourceException;
 
 /**
  * Classe de test du contrôleur de groupe
@@ -259,8 +260,8 @@ final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARes
      */
     public function testDeleteNotFound()
     {
-        $this->repository->getMockController()->getOne = function () {
-            throw new \DomainException('');
+        $this->repository->getMockController()->deleteOne = function () {
+            throw new UnknownResourceException('');
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
@@ -274,7 +275,7 @@ final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARes
      */
     public function testDeleteFallback()
     {
-        $this->repository->getMockController()->getOne = function () {
+        $this->repository->getMockController()->deleteOne = function () {
             throw new \LogicException('');
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
@@ -288,7 +289,6 @@ final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARes
      */
     public function testDeleteOk()
     {
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->deleteOne = 123;
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 

--- a/Tests/Units/Groupe/GroupeController.php
+++ b/Tests/Units/Groupe/GroupeController.php
@@ -172,43 +172,11 @@ final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARes
     }
 
     /**
-     * Teste la méthode put avec un détail non trouvé (id en Bad domaine)
-     */
-    public function testPutNotFound()
-    {
-        $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = function () {
-            throw new \DomainException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-
-        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
-
-        $this->boolean($response->isNotFound())->isTrue();
-    }
-
-    /**
-     * Teste le fallback de la méthode getOne du put
-     */
-    public function testPutGetOneFallback()
-    {
-        $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = function () {
-            throw new \LogicException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-
-        $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);
-        $this->assertError($response);
-    }
-
-    /**
      * Teste la méthode put avec un argument de body manquant
      */
     public function testPutMissingRequiredArg()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->entite;
 
         $this->repository->getMockController()->putOne = function () {
             throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
@@ -226,7 +194,6 @@ final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARes
     public function testPutBadDomain()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \DomainException('');
         };
@@ -243,7 +210,6 @@ final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARes
     public function testPutPutOneFallback()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \LogicException('');
         };
@@ -259,8 +225,7 @@ final class GroupeController extends \LibertAPI\Tests\Units\Tools\Libraries\ARes
     public function testPutOk()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
-        $this->repository->getMockController()->putOne = '';
+        $this->repository->getMockController()->putOne = $this->entite;
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
         $response = $this->testedInstance->put($this->request, $this->response, ['groupeId' => 99]);

--- a/Tests/Units/Groupe/GroupeRepository.php
+++ b/Tests/Units/Groupe/GroupeRepository.php
@@ -20,4 +20,13 @@ final class GroupeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARep
             'g_double_valid' => 'Y'
         ];
     }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+            'name' => 'Spartan',
+            'comment' => 'Mario',
+            'double_validation' => 'N',
+        ];
+    }
 }

--- a/Tests/Units/Groupe/Responsable/ResponsableRepository.php
+++ b/Tests/Units/Groupe/Responsable/ResponsableRepository.php
@@ -75,7 +75,7 @@ final class ResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libraries
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->deleteOne(987);
         })->isInstanceOf(\RuntimeException::class);
     }
 }

--- a/Tests/Units/Groupe/Responsable/ResponsableRepository.php
+++ b/Tests/Units/Groupe/Responsable/ResponsableRepository.php
@@ -60,7 +60,7 @@ final class ResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libraries
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->putOne(98, []);
         })->isInstanceOf(\RuntimeException::class);
     }
 

--- a/Tests/Units/Groupe/Responsable/ResponsableRepository.php
+++ b/Tests/Units/Groupe/Responsable/ResponsableRepository.php
@@ -51,7 +51,7 @@ final class ResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libraries
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->postOne([], new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->postOne($this->getConsumerContent());
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -62,6 +62,12 @@ final class ResponsableRepository extends \LibertAPI\Tests\Units\Tools\Libraries
         $this->exception(function () {
             $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
         })->isInstanceOf(\RuntimeException::class);
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+        ];
     }
 
     public function testDeleteOne()

--- a/Tests/Units/JourFerie/JourFerieRepository.php
+++ b/Tests/Units/JourFerie/JourFerieRepository.php
@@ -41,7 +41,7 @@ final class JourFerieRepository extends \LibertAPI\Tests\Units\Tools\Libraries\A
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->putOne(81273, []);
         })->isInstanceOf(\RuntimeException::class);
     }
 

--- a/Tests/Units/JourFerie/JourFerieRepository.php
+++ b/Tests/Units/JourFerie/JourFerieRepository.php
@@ -56,7 +56,7 @@ final class JourFerieRepository extends \LibertAPI\Tests\Units\Tools\Libraries\A
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->deleteOne(518);
         })->isInstanceOf(\RuntimeException::class);
     }
 }

--- a/Tests/Units/JourFerie/JourFerieRepository.php
+++ b/Tests/Units/JourFerie/JourFerieRepository.php
@@ -32,7 +32,7 @@ final class JourFerieRepository extends \LibertAPI\Tests\Units\Tools\Libraries\A
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->postOne([], new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->postOne($this->getConsumerContent());
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -43,6 +43,12 @@ final class JourFerieRepository extends \LibertAPI\Tests\Units\Tools\Libraries\A
         $this->exception(function () {
             $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
         })->isInstanceOf(\RuntimeException::class);
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+        ];
     }
 
     public function testDeleteOne()

--- a/Tests/Units/Journal/JournalRepository.php
+++ b/Tests/Units/Journal/JournalRepository.php
@@ -46,7 +46,7 @@ final class JournalRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->putOne(8712, []);
         })->isInstanceOf(\RuntimeException::class);
     }
 

--- a/Tests/Units/Journal/JournalRepository.php
+++ b/Tests/Units/Journal/JournalRepository.php
@@ -61,7 +61,7 @@ final class JournalRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->deleteOne(723);
         })->isInstanceOf(\RuntimeException::class);
     }
 }

--- a/Tests/Units/Journal/JournalRepository.php
+++ b/Tests/Units/Journal/JournalRepository.php
@@ -37,7 +37,7 @@ final class JournalRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->postOne([], new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->postOne($this->getConsumerContent());
         })->isInstanceOf(\RuntimeException::class);
     }
 
@@ -48,6 +48,12 @@ final class JournalRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->exception(function () {
             $this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
         })->isInstanceOf(\RuntimeException::class);
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+        ];
     }
 
     public function testDeleteOne()

--- a/Tests/Units/Planning/Creneau/CreneauController.php
+++ b/Tests/Units/Planning/Creneau/CreneauController.php
@@ -150,37 +150,6 @@ final class CreneauController extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
     }
 
     /**
-     * Teste la méthode put avec un détail non trouvé (id en Bad domaine)
-     */
-    public function testPutNotFound()
-    {
-        $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = function () {
-            throw new \DomainException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-
-        $response = $this->testedInstance->put($this->request, $this->response, ['creneauId' => 99, 'planningId' => 11]);
-
-        $this->boolean($response->isNotFound())->isTrue();
-    }
-
-    /**
-     * Teste le fallback de la méthode getOne du put
-     */
-    public function testPutGetOneFallback()
-    {
-        $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = function () {
-            throw new \LogicException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-
-        $response = $this->testedInstance->put($this->request, $this->response, ['creneauId' => 99, 'planningId' => 11]);
-        $this->assertError($response);
-    }
-
-    /**
      * Teste la méthode put avec un argument de body manquant
      */
     public function testPutMissingRequiredArg()
@@ -221,7 +190,6 @@ final class CreneauController extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
     public function testPutPutOneFallback()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \LogicException('');
         };
@@ -237,8 +205,7 @@ final class CreneauController extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
     public function testPutOk()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
-        $this->repository->getMockController()->putOne = '';
+        $this->repository->getMockController()->putOne = $this->entite;
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
         $response = $this->testedInstance->put($this->request, $this->response, ['creneauId' => 99, 'planningId' => 11]);

--- a/Tests/Units/Planning/Creneau/CreneauRepository.php
+++ b/Tests/Units/Planning/Creneau/CreneauRepository.php
@@ -34,6 +34,18 @@ final class CreneauRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         ];
     }
 
+    protected function getConsumerContent() : array
+    {
+        return [
+            'planningId' => 12,
+            'jourId' => 4,
+            'typeSemaine' => 54,
+            'typePeriode' => 191283,
+            'debut' => 921,
+            'fin' => 2139123,
+        ];
+    }
+
     public function testDeleteOne()
     {
         $this->newTestedInstance($this->connector);

--- a/Tests/Units/Planning/Creneau/CreneauRepository.php
+++ b/Tests/Units/Planning/Creneau/CreneauRepository.php
@@ -21,6 +21,16 @@ final class CreneauRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         })->isInstanceOf(\RuntimeException::class);
     }
 
+    public function testPutOne()
+    {
+        $this->newTestedInstance($this->connector);
+        $this->calling($this->result)->fetch = [];
+
+        $this->exception(function () {
+            $this->testedInstance->putOne(4, []);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
     final protected function getStorageContent() : array
     {
         return [

--- a/Tests/Units/Planning/Creneau/CreneauRepository.php
+++ b/Tests/Units/Planning/Creneau/CreneauRepository.php
@@ -61,7 +61,7 @@ final class CreneauRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARe
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->deleteOne(111);
         })->isInstanceOf(\RuntimeException::class);
     }
 }

--- a/Tests/Units/Planning/PlanningController.php
+++ b/Tests/Units/Planning/PlanningController.php
@@ -174,43 +174,11 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
     }
 
     /**
-     * Teste la méthode put avec un détail non trouvé (id en Bad domaine)
-     */
-    public function testPutNotFound()
-    {
-        $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = function () {
-            throw new \DomainException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-
-        $response = $this->testedInstance->put($this->request, $this->response, ['planningId' => 99]);
-
-        $this->boolean($response->isNotFound())->isTrue();
-    }
-
-    /**
-     * Teste le fallback de la méthode getOne du put
-     */
-    public function testPutGetOneFallback()
-    {
-        $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = function () {
-            throw new \LogicException('');
-        };
-        $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
-
-        $response = $this->testedInstance->put($this->request, $this->response, ['planningId' => 99]);
-        $this->assertError($response);
-    }
-
-    /**
      * Teste la méthode put avec un argument de body manquant
      */
     public function testPutMissingRequiredArg()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->entite;
 
         $this->repository->getMockController()->putOne = function () {
             throw new \LibertAPI\Tools\Exceptions\MissingArgumentException('');
@@ -228,7 +196,6 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
     public function testPutBadDomain()
     {
         $this->request->getMockController()->getParsedBody = [];
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \DomainException('');
         };
@@ -245,7 +212,6 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
     public function testPutPutOneFallback()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->putOne = function () {
             throw new \LogicException('');
         };
@@ -261,8 +227,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
     public function testPutOk()
     {
         $this->request->getMockController()->getParsedBody = $this->getEntiteContent();
-        $this->repository->getMockController()->getOne = $this->entite;
-        $this->repository->getMockController()->putOne = '';
+        $this->repository->getMockController()->putOne = $this->entite;
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
         $response = $this->testedInstance->put($this->request, $this->response, ['planningId' => 99]);

--- a/Tests/Units/Planning/PlanningController.php
+++ b/Tests/Units/Planning/PlanningController.php
@@ -2,6 +2,7 @@
 namespace LibertAPI\Tests\Units\Planning;
 
 use Psr\Http\Message\ResponseInterface as IResponse;
+use LibertAPI\Tools\Exceptions\UnknownResourceException;
 
 /**
  * Classe de test du contrôleur de planning
@@ -260,8 +261,8 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
      */
     public function testDeleteNotFound()
     {
-        $this->repository->getMockController()->getOne = function () {
-            throw new \DomainException('');
+        $this->repository->getMockController()->deleteOne = function () {
+            throw new UnknownResourceException('');
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 
@@ -275,7 +276,7 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
      */
     public function testDeleteFallback()
     {
-        $this->repository->getMockController()->getOne = function () {
+        $this->repository->getMockController()->deleteOne = function () {
             throw new \LogicException('');
         };
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
@@ -289,7 +290,6 @@ final class PlanningController extends \LibertAPI\Tests\Units\Tools\Libraries\AR
      */
     public function testDeleteOk()
     {
-        $this->repository->getMockController()->getOne = $this->entite;
         $this->repository->getMockController()->deleteOne = 89172;
         $this->newTestedInstance($this->repository, $this->router, $this->currentEmploye);
 

--- a/Tests/Units/Planning/PlanningRepository.php
+++ b/Tests/Units/Planning/PlanningRepository.php
@@ -19,4 +19,12 @@ final class PlanningRepository extends \LibertAPI\Tests\Units\Tools\Libraries\AR
             'status' => 59,
         ];
     }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+            'name' => 'Pomme',
+            'status' => 'green',
+        ];
+    }
 }

--- a/Tests/Units/Tools/Libraries/ARepository.php
+++ b/Tests/Units/Tools/Libraries/ARepository.php
@@ -90,9 +90,10 @@ abstract class ARepository extends \Atoum
     {
         $this->newTestedInstance($this->connector);
         $this->calling($this->queryBuilder)->execute = $this->result;
+        $this->calling($this->result)->fetch = $this->getStorageContent();
         $this->calling($this->result)->rowCount = 123;
 
-        $this->integer($this->testedInstance->deleteOne(new \mock\LibertAPI\Tools\Libraries\AEntite([])))->isIdenticalTo(123);
+        $this->integer($this->testedInstance->deleteOne(4))->isIdenticalTo(123);
     }
 
     /**

--- a/Tests/Units/Tools/Libraries/ARepository.php
+++ b/Tests/Units/Tools/Libraries/ARepository.php
@@ -71,7 +71,8 @@ abstract class ARepository extends \Atoum
         $this->calling($this->queryBuilder)->execute = true;
         $this->calling($this->connector)->lastInsertId = 9182;
 
-        $this->integer($this->testedInstance->postOne([], new \mock\LibertAPI\Tools\Libraries\AEntite([])))->isIdenticalTo(9182);
+        $this->integer($this->testedInstance->postOne($this->getConsumerContent()))
+            ->isIdenticalTo(9182);
     }
 
     public function testPutOne()
@@ -82,6 +83,8 @@ abstract class ARepository extends \Atoum
 
         $this->variable($this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([])))->isNull();
     }
+
+    abstract protected function getConsumerContent() : array;
 
     public function testDeleteOne()
     {

--- a/Tests/Units/Tools/Libraries/ARepository.php
+++ b/Tests/Units/Tools/Libraries/ARepository.php
@@ -2,6 +2,7 @@
 namespace LibertAPI\Tests\Units\Tools\Libraries;
 
 use LibertAPI\Tools\Libraries\AEntite;
+use \LibertAPI\Tools\Exceptions\UnknownResourceException;
 
 /**
  * Classe de test des repositories
@@ -37,7 +38,7 @@ abstract class ARepository extends \Atoum
 
         $this->exception(function () {
             $this->testedInstance->getOne(4);
-        })->isInstanceOf(\DomainException::class);
+        })->isInstanceOf(UnknownResourceException::class);
     }
 
     public function testGetListEmpty()
@@ -78,10 +79,9 @@ abstract class ARepository extends \Atoum
     public function testPutOne()
     {
         $this->newTestedInstance($this->connector);
-        $this->calling($this->queryBuilder)->execute = true;
-        $this->calling($this->connector)->lastInsertId = 9182;
+        $this->calling($this->result)->fetch = $this->getStorageContent();
 
-        $this->variable($this->testedInstance->putOne(new \mock\LibertAPI\Tools\Libraries\AEntite([])))->isNull();
+        $this->variable($this->testedInstance->putOne(55, $this->getConsumerContent()))->isNull();
     }
 
     abstract protected function getConsumerContent() : array;

--- a/Tests/Units/Utilisateur/UtilisateurRepository.php
+++ b/Tests/Units/Utilisateur/UtilisateurRepository.php
@@ -21,6 +21,14 @@ final class UtilisateurRepository extends \LibertAPI\Tests\Units\Tools\Libraries
         })->isInstanceOf(\RuntimeException::class);
     }
 
+    public function testPutOne()
+    {
+        $this->newTestedInstance($this->connector);
+        $this->exception(function () {
+            $this->testedInstance->putOne(4, []);
+        })->isInstanceOf(\RuntimeException::class);
+    }
+
     final protected function getStorageContent() : array
     {
         return [

--- a/Tests/Units/Utilisateur/UtilisateurRepository.php
+++ b/Tests/Units/Utilisateur/UtilisateurRepository.php
@@ -49,8 +49,14 @@ final class UtilisateurRepository extends \LibertAPI\Tests\Units\Tools\Libraries
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->postOne([], new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->postOne($this->getConsumerContent());
         })->isInstanceOf(\RuntimeException::class);
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+        ];
     }
 
     public function testDeleteOne()

--- a/Tests/Units/Utilisateur/UtilisateurRepository.php
+++ b/Tests/Units/Utilisateur/UtilisateurRepository.php
@@ -72,7 +72,7 @@ final class UtilisateurRepository extends \LibertAPI\Tests\Units\Tools\Libraries
         $this->newTestedInstance($this->connector);
 
         $this->exception(function () {
-            $this->testedInstance->deleteOne(new \mock\LibertAPI\Tools\Libraries\AEntite([]));
+            $this->testedInstance->deleteOne(345);
         })->isInstanceOf(\RuntimeException::class);
     }
 }

--- a/Tools/Exceptions/UnknownResourceException.php
+++ b/Tools/Exceptions/UnknownResourceException.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tools\Exceptions;
+
+/**
+ * Exception déclenchée en cas de ressource inconnue manquante
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.1
+ *
+ * Ne devrait être contacté que par *Repository
+ * Ne devrait contacter personne
+ */
+class UnknownResourceException extends \Exception
+{
+}

--- a/Tools/Libraries/ARepository.php
+++ b/Tools/Libraries/ARepository.php
@@ -3,6 +3,7 @@ namespace LibertAPI\Tools\Libraries;
 
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Query\QueryBuilder;
+use \LibertAPI\Tools\Exceptions\UnknownResourceException;
 
 /**
  * Garant de la cohérence métier de l'entité en relation.
@@ -42,7 +43,7 @@ abstract class ARepository
      * @param int $id Id potentiel de ressource
      *
      * @return AEntite
-     * @throws \DomainException Si $id n'est pas dans le domaine de définition
+     * @throws UnknownResourceException Si $id n'est pas dans le domaine de définition
      */
     public function getOne(int $id) : AEntite
     {
@@ -52,7 +53,7 @@ abstract class ARepository
 
         $data = $res->fetch(\PDO::FETCH_ASSOC);
         if (empty($data)) {
-            throw new \DomainException('#' . $id . ' is not a valid resource');
+            throw new UnknownResourceException('#' . $id . ' is not a valid resource');
         }
 
         $entiteClass = $this->getEntiteClass();
@@ -143,10 +144,13 @@ abstract class ARepository
     /**
      * Met à jour une ressource unique
      *
-     * @param AEntite $entite mise à jour
+     * @param int $id ID de la ressource
+     * @param array $data Données à mettre à jour
      */
-    public function putOne(AEntite $entite)
+    public function putOne(int $id, array $data)
     {
+        $entite = $this->getOne($id);
+        $entite->populate($data);
         $this->queryBuilder->update($this->getTableName());
         $this->setSet($this->getEntite2Storage($entite));
         $this->setWhere(['id', $entite->getId()]);

--- a/Tools/Libraries/ARepository.php
+++ b/Tools/Libraries/ARepository.php
@@ -182,8 +182,9 @@ abstract class ARepository
      *
      * @param AEntite $entite
      */
-    public function deleteOne(AEntite $entite) : int
+    public function deleteOne(int $id) : int
     {
+        $entite = $this->getOne($id);
         $this->queryBuilder->delete($this->getTableName());
         $this->setWhere(['id' => $entite->getId()]);
         $res = $this->queryBuilder->execute();

--- a/Tools/Libraries/ARepository.php
+++ b/Tools/Libraries/ARepository.php
@@ -118,12 +118,13 @@ abstract class ARepository
      * Poste une ressource unique
      *
      * @param array $data Données à poster
-     * @param AEntite $entite [Vide par définition]
      *
      * @return int Id de la ressource nouvellement insérée
      */
-    public function postOne(array $data, AEntite $entite) : int
+    public function postOne(array $data) : int
     {
+        $entiteClass = $this->getEntiteClass();
+        $entite = new $entiteClass([]);
         $entite->populate($data);
         $this->queryBuilder->insert($this->getTableName());
         $this->setValues($this->getEntite2Storage($entite));

--- a/Utilisateur/UtilisateurRepository.php
+++ b/Utilisateur/UtilisateurRepository.php
@@ -125,7 +125,7 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
         return $results;
     }
 
-    public function postOne(array $data, AEntite $entite) : int
+    public function postOne(array $data) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Utilisateur/UtilisateurRepository.php
+++ b/Utilisateur/UtilisateurRepository.php
@@ -265,7 +265,7 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
         return password_hash($instanceToken, \PASSWORD_BCRYPT);
     }
 
-    public function deleteOne(AEntite $entite) : int
+    public function deleteOne(int $id) : int
     {
         throw new \RuntimeException('Action is forbidden');
     }

--- a/Utilisateur/UtilisateurRepository.php
+++ b/Utilisateur/UtilisateurRepository.php
@@ -130,8 +130,10 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
         throw new \RuntimeException('Action is forbidden');
     }
 
-    public function putOne(AEntite $entite)
+    public function putOne(int $id, array $data)
     {
+        $entite = $this->getOne($id);
+        $entite->populate($data);
         $this->queryBuilder->update($this->getTableName());
         $this->setSet($this->getEntite2Storage($entite));
         $this->queryBuilder->where('u_login = :id');


### PR DESCRIPTION
Les responsabilités étaient bien designées, à ceci près que dans les ordres ReST non safe (POST, PUT, DELETE), le contrôleur faisait un remplissage et / ou vérification sur l'existence de l'entité. Ces opérations étant du ressort du repo, je les déplace donc.