### PR TITLE
Allow ':' in password

### DIFF
--- a/Tools/Services/InterneAuthentifierService.php
+++ b/Tools/Services/InterneAuthentifierService.php
@@ -32,7 +32,7 @@ class InterneAuthentifierService extends AAuthentifierFactoryService
         }
 
         $authentification = substr($authentification, strlen($authentificationType) + 1);
-        list($this->login, $password) = explode(':', base64_decode($authentification));
+        list($this->login, $password) = explode(':', base64_decode($authentification), 2);
 
         $utilisateur = $this->getRepository()->find([
             'login' => $this->login,


### PR DESCRIPTION
Hi,

This PR corrects a bug where `:` is not allowed in passwords.
(it replaces https://github.com/libertempo/web/pull/723)

Thank you 👍 