### PR TITLE
Choix du protocole pour ldap

### DIFF
--- a/Tools/Services/LdapAuthentifierService.php
+++ b/Tools/Services/LdapAuthentifierService.php
@@ -43,20 +43,14 @@ class LdapAuthentifierService extends AAuthentifierFactoryService
 
         $this->ldap->addProvider($config);
 
-        try {
-            $wheres = [
-                $configurationLdap->login . '=' . $this->getLogin(),
-                $configurationLdap->domaine,
-            ];
-            $provider = $this->ldap->connect();
-            $result = $provider->search()->findByDnOrFail(implode(',', $wheres));
+        $rdn = [
+            $configurationLdap->login . '=' . $this->getLogin(),
+            $configurationLdap->domaine,
+        ];
+        $provider = $this->ldap->connect();
+        $connection = $provider->getConnection();
 
-            return $this->getPassword() === $result->getFirstAttribute('userpassword');
-        } catch (\Adldap\Auth\BindException $e) {
-            return false;
-        } catch (\Adldap\Models\ModelNotFoundException $e) {
-            return false;
-        }
+        return $connection->bind(implode(',', $rdn), $this->getPassword());
     }
 
     /**

--- a/Tools/Services/LdapAuthentifierService.php
+++ b/Tools/Services/LdapAuthentifierService.php
@@ -29,11 +29,16 @@ class LdapAuthentifierService extends AAuthentifierFactoryService
         assert(isset($request->getAttribute('configurationFileData')->ldap));
         $configurationLdap = $request->getAttribute('configurationFileData')->ldap;
 
+        $scheme = parse_url($configurationLdap->serveur, PHP_URL_SCHEME);
+        $hostOne = parse_url($configurationLdap->serveur, PHP_URL_HOST);
+        $hostTwo = parse_url($configurationLdap->up_serveur, PHP_URL_HOST);
+
         $config = [
-          'hosts'    => [$configurationLdap->serveur, $configurationLdap->up_serveur],
+          'hosts'    => [$hostOne, $hostTwo],
           'base_dn'  => $configurationLdap->base,
           'username' => $configurationLdap->utilisateur,
           'password' => $configurationLdap->mot_de_passe,
+          'use_ssl' => isset($scheme) && 's' === substr($scheme, -1, 1),
         ];
 
         $this->ldap->addProvider($config);


### PR DESCRIPTION
À l'origine, l'utilisateur avait le choix ou non d'avoir une connexion sécurisée. #51 a enlevé ce choix alors je le remets, en découvrant automatiquement ce que l'utilisateur voulait.
Au passage, la méthode précédent de vérification des identifiants dans le serveur LDAP n'était pas adapté à tous, on trouve donc une méthode plus générale.