### PR TITLE
explode uniquement le premier ":"

### DIFF
--- a/Tools/Services/AAuthentifierFactoryService.php
+++ b/Tools/Services/AAuthentifierFactoryService.php
@@ -59,7 +59,7 @@ abstract class AAuthentifierFactoryService
         }
 
         $authentification = substr($authentification, strlen($authentificationType) + 1);
-        list($login, $password) = explode(':', base64_decode($authentification),2);
+        list($login, $password) = explode(':', base64_decode($authentification), 2);
         $this->setLogin($login);
         $this->setPassword($password);
     }

--- a/Tools/Services/AAuthentifierFactoryService.php
+++ b/Tools/Services/AAuthentifierFactoryService.php
@@ -59,7 +59,7 @@ abstract class AAuthentifierFactoryService
         }
 
         $authentification = substr($authentification, strlen($authentificationType) + 1);
-        list($login, $password) = explode(':', base64_decode($authentification));
+        list($login, $password) = explode(':', base64_decode($authentification),2);
         $this->setLogin($login);
         $this->setPassword($password);
     }


### PR DESCRIPTION
Si le caractère ":" est contenu dans le mot de passe, `explode()` l'interprétait comme un séparateur de champ. Ce patch limite simplement `explode()` à 2 champs.