### PR TITLE
Heure de repos pour l'employé

### DIFF
--- a/Heure/Repos/ReposEntite.php
+++ b/Heure/Repos/ReposEntite.php
@@ -19,80 +19,64 @@ class ReposEntite extends \LibertAPI\Tools\Libraries\AEntite
 {
     /**
      * Retourne la donnée la plus à jour du champ login
-     *
-     * @return string
      */
-    public function getLogin()
+    public function getLogin() : string
     {
         return $this->getFreshData('login');
     }
 
     /**
      * Retourne la donnée la plus à jour du champ debut
-     *
-     * @return string
      */
-    public function getDebut()
+    public function getDebut() : int
     {
         return $this->getFreshData('debut');
     }
 
     /**
      * Retourne la donnée la plus à jour du champ fin
-     *
-     * @return string
      */
-    public function getFin()
+    public function getFin() : int
     {
         return $this->getFreshData('fin');
     }
 
     /**
      * Retourne la donnée la plus à jour du champ duree
-     *
-     * @return string
      */
-    public function getDuree()
+    public function getDuree() : int
     {
         return $this->getFreshData('duree');
     }
 
     /**
      * Retourne la donnée la plus à jour du champ type_periode
-     *
-     * @return string
      */
-    public function getTypePeriode()
+    public function getTypePeriode() : int
     {
         return $this->getFreshData('type_periode');
     }
 
     /**
      * Retourne la donnée la plus à jour du champ statut
-     *
-     * @return string
      */
-    public function getStatut()
+    public function getStatut() : int
     {
         return $this->getFreshData('statut');
     }
 
     /**
      * Retourne la donnée la plus à jour du champ commentaire
-     *
-     * @return string
      */
-    public function getCommentaire()
+    public function getCommentaire() : string
     {
         return $this->getFreshData('commentaire');
     }
 
     /**
      * Retourne la donnée la plus à jour du champ commentaire_refus
-     *
-     * @return string
      */
-    public function getCommentaireRefus()
+    public function getCommentaireRefus() : string
     {
         return $this->getFreshData('commentaire_refus');
     }

--- a/Heure/Repos/ReposEntite.php
+++ b/Heure/Repos/ReposEntite.php
@@ -18,33 +18,73 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
 class ReposEntite extends \LibertAPI\Tools\Libraries\AEntite
 {
     /**
-     * Retourne la donnée la plus à jour du champ name
+     * Retourne la donnée la plus à jour du champ login
      *
      * @return string
      */
-    public function getName()
+    public function getLogin()
     {
-        return $this->getFreshData('name');
+        return $this->getFreshData('login');
     }
 
     /**
-     * Retourne la donnée la plus à jour du champ comment
+     * Retourne la donnée la plus à jour du champ debut
      *
      * @return string
      */
-    public function getComment()
+    public function getDebut()
     {
-        return $this->getFreshData('comment');
+        return $this->getFreshData('debut');
     }
 
     /**
-     * Retourne la donnée la plus à jour du champ de double validation
+     * Retourne la donnée la plus à jour du champ fin
      *
-     * @return bool
+     * @return string
      */
-    public function isDoubleValidated()
+    public function getFin()
     {
-        return (bool) $this->getFreshData('double_validation');
+        return $this->getFreshData('fin');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ type_periode
+     *
+     * @return string
+     */
+    public function getTypePeriode()
+    {
+        return $this->getFreshData('type_periode');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ statut
+     *
+     * @return string
+     */
+    public function getStatut()
+    {
+        return $this->getFreshData('statut');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ commentaire
+     *
+     * @return string
+     */
+    public function getCommentaire()
+    {
+        return $this->getFreshData('commentaire');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ commentaire_refus
+     *
+     * @return string
+     */
+    public function getCommentaireRefus()
+    {
+        return $this->getFreshData('commentaire_refus');
     }
 
     /**
@@ -52,15 +92,5 @@ class ReposEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     public function populate(array $data)
     {
-    }
-
-    /**
-     * Retourne la liste des champs requis
-     *
-     * @return array
-     */
-    private function getListRequired()
-    {
-        return [];
     }
 }

--- a/Heure/Repos/ReposEntite.php
+++ b/Heure/Repos/ReposEntite.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Heure\Repos;
+
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+
+/**
+ * @inheritDoc
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.8
+ * @see \LibertAPI\Tests\Units\Heure\Repos\ReposEntite
+ *
+ * Ne devrait être contacté que par le ReposRepository
+ * Ne devrait contacter personne
+ */
+class ReposEntite extends \LibertAPI\Tools\Libraries\AEntite
+{
+    /**
+     * Retourne la donnée la plus à jour du champ name
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getFreshData('name');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ comment
+     *
+     * @return string
+     */
+    public function getComment()
+    {
+        return $this->getFreshData('comment');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ de double validation
+     *
+     * @return bool
+     */
+    public function isDoubleValidated()
+    {
+        return (bool) $this->getFreshData('double_validation');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function populate(array $data)
+    {
+    }
+
+    /**
+     * Retourne la liste des champs requis
+     *
+     * @return array
+     */
+    private function getListRequired()
+    {
+        return [];
+    }
+}

--- a/Heure/Repos/ReposEntite.php
+++ b/Heure/Repos/ReposEntite.php
@@ -48,6 +48,16 @@ class ReposEntite extends \LibertAPI\Tools\Libraries\AEntite
     }
 
     /**
+     * Retourne la donnée la plus à jour du champ duree
+     *
+     * @return string
+     */
+    public function getDuree()
+    {
+        return $this->getFreshData('duree');
+    }
+
+    /**
      * Retourne la donnée la plus à jour du champ type_periode
      *
      * @return string

--- a/Heure/Repos/ReposRepository.php
+++ b/Heure/Repos/ReposRepository.php
@@ -73,7 +73,7 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
     {
         if (array_key_exists('login', $parametres)) {
             $this->queryBuilder->andWhere('login = :login');
-            $this->queryBuilder->setParameter(':login', (int) $parametres['login']);
+            $this->queryBuilder->setParameter(':login', $parametres['login']);
         }
     }
 

--- a/Heure/Repos/ReposRepository.php
+++ b/Heure/Repos/ReposRepository.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types = 1);
-namespace LibertAPI\Groupe;
+namespace LibertAPI\Heure\Repos;
 
 use LibertAPI\Tools\Libraries\AEntite;
 
@@ -10,12 +10,12 @@ use LibertAPI\Tools\Libraries\AEntite;
  * @author Wouldsmina
  *
  * @since 0.7
- * @see \LibertAPI\Tests\Units\Groupe\GroupeRepository
+ * @see \LibertAPI\Tests\Units\Heure\Repos\ReposRepository
  *
- * Ne devrait être contacté que par le GroupeController
- * Ne devrait contacter que le GroupeEntite
+ * Ne devrait être contacté que par le HeureReposUtilisateurController
+ * Ne devrait contacter que le ReposEntite
  */
-class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
+class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
 {
     final protected function getEntiteClass() : string
     {
@@ -57,18 +57,6 @@ class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
 
     final protected function setSet(array $parametres)
     {
-        if (!empty($parametres['name'])) {
-            $this->queryBuilder->set('g_groupename', ':name');
-            $this->queryBuilder->setParameter(':name', $parametres['name']);
-        }
-        if (!empty($parametres['comment'])) {
-            $this->queryBuilder->set('g_comment', ':comment');
-            $this->queryBuilder->setParameter(':comment', $parametres['comment']);
-        }
-        if (!empty($parametres['double_validation'])) {
-            $this->queryBuilder->set('g_double_valid', ':double_validation');
-            $this->queryBuilder->setParameter(':double_validation', $parametres['double_validation']);
-        }
     }
 
     /**
@@ -87,11 +75,7 @@ class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function getEntite2Storage(AEntite $entite) : array
     {
-        return [
-            'name' => $entite->getName(),
-            'comment' => $entite->getComment(),
-            'double_validation' => 'Y' === $entite->isDoubleValidated()
-        ];
+        return [];
     }
 
     /**
@@ -99,6 +83,21 @@ class GroupeRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function getTableName() : string
     {
-        return 'conges_groupe';
+        return 'heure_repos';
     }
+
+//     +---------------+------------------+------+-----+---------+----------------+
+// | Field         | Type             | Null | Key | Default | Extra          |
+// +---------------+------------------+------+-----+---------+----------------+
+// | id_heure      | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
+// | login         | varbinary(99)    | NO   |     | NULL    |                |
+// | debut         | int(11)          | NO   |     | NULL    |                |
+// | fin           | int(11)          | NO   |     | NULL    |                |
+// | duree         | int(11)          | NO   |     | NULL    |                |
+// | type_periode  | int(3)           | NO   |     | NULL    |                |
+// | statut        | int(11)          | NO   |     | 0       |                |
+// | comment       | varchar(250)     | NO   |     |         |                |
+// | comment_refus | varchar(250)     | NO   |     |         |                |
+// +---------------+------------------+------+-----+---------+----------------+
+
 }

--- a/Heure/Repos/ReposRepository.php
+++ b/Heure/Repos/ReposRepository.php
@@ -43,7 +43,7 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
             'fin' => (int) $dataStorage['fin'],
             'duree' => (int) $dataStorage['duree'],
             'type_periode' => (int) $dataStorage['type_periode'],
-            'statut' => $dataStorage['statut'],
+            'statut' => (int) $dataStorage['statut'],
             'commentaire' => $dataStorage['comment'],
             'commentaire_refus' => $dataStorage['comment_refus'],
         ];

--- a/Heure/Repos/ReposRepository.php
+++ b/Heure/Repos/ReposRepository.php
@@ -12,7 +12,7 @@ use LibertAPI\Tools\Libraries\AEntite;
  * @since 1.8
  * @see \LibertAPI\Tests\Units\Heure\Repos\ReposRepository
  *
- * Ne devrait être contacté que par le HeureReposUtilisateurController
+ * Ne devrait être contacté que par le HeureReposEmployeController
  * Ne devrait contacter que le ReposEntite
  */
 class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository

--- a/Heure/Repos/ReposRepository.php
+++ b/Heure/Repos/ReposRepository.php
@@ -9,7 +9,7 @@ use LibertAPI\Tools\Libraries\AEntite;
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
- * @since 0.7
+ * @since 1.8
  * @see \LibertAPI\Tests\Units\Heure\Repos\ReposRepository
  *
  * Ne devrait être contacté que par le HeureReposUtilisateurController
@@ -19,7 +19,7 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
 {
     final protected function getEntiteClass() : string
     {
-        return GroupeEntite::class;
+        return ReposEntite::class;
     }
 
     /**
@@ -37,10 +37,15 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
     final protected function getStorage2Entite(array $dataStorage)
     {
         return [
-            'id' => $dataStorage['g_gid'],
-            'name' => $dataStorage['g_groupename'],
-            'comment' => $dataStorage['g_comment'],
-            'double_validation' => 'Y' === $dataStorage['g_double_valid']
+            'id' => $dataStorage['id_heure'],
+            'login' => $dataStorage['login'],
+            'debut' => (int) $dataStorage['debut'],
+            'fin' => (int) $dataStorage['fin'],
+            'duree' => (int) $dataStorage['duree'],
+            'type_periode' => (int) $dataStorage['type_periode'],
+            'statut' => $dataStorage['statut'],
+            'commentaire' => $dataStorage['comment'],
+            'commentaire_refus' => $dataStorage['comment_refus'],
         ];
     }
 
@@ -49,14 +54,12 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function setValues(array $values)
     {
-        $this->queryBuilder->setValue('g_groupename', ':name');
-        $this->queryBuilder->setParameter(':name', $values['name']);
-        $this->queryBuilder->setValue('g_comment', $values['comment']);
-        $this->queryBuilder->setValue('g_double_valid', $values['double_validation']);
+        unset($values);
     }
 
     final protected function setSet(array $parametres)
     {
+        unset($parametres);
     }
 
     /**
@@ -75,6 +78,7 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function getEntite2Storage(AEntite $entite) : array
     {
+        unset($entite);
         return [];
     }
 
@@ -85,19 +89,4 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
     {
         return 'heure_repos';
     }
-
-//     +---------------+------------------+------+-----+---------+----------------+
-// | Field         | Type             | Null | Key | Default | Extra          |
-// +---------------+------------------+------+-----+---------+----------------+
-// | id_heure      | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
-// | login         | varbinary(99)    | NO   |     | NULL    |                |
-// | debut         | int(11)          | NO   |     | NULL    |                |
-// | fin           | int(11)          | NO   |     | NULL    |                |
-// | duree         | int(11)          | NO   |     | NULL    |                |
-// | type_periode  | int(3)           | NO   |     | NULL    |                |
-// | statut        | int(11)          | NO   |     | 0       |                |
-// | comment       | varchar(250)     | NO   |     |         |                |
-// | comment_refus | varchar(250)     | NO   |     |         |                |
-// +---------------+------------------+------+-----+---------+----------------+
-
 }

--- a/Heure/Repos/ReposRepository.php
+++ b/Heure/Repos/ReposRepository.php
@@ -27,8 +27,12 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function getParamsConsumer2Storage(array $paramsConsumer) : array
     {
-        unset($paramsConsumer);
-        return [];
+        $results = [];
+        if (array_key_exists('login', $paramsConsumer)) {
+            $results['login'] = (string) $paramsConsumer['login'];
+        }
+
+        return $results;
     }
 
     /**
@@ -67,9 +71,9 @@ class ReposRepository extends \LibertAPI\Tools\Libraries\ARepository
      */
     final protected function setWhere(array $parametres)
     {
-        if (array_key_exists('id', $parametres)) {
-            $this->queryBuilder->andWhere('g_gid = :id');
-            $this->queryBuilder->setParameter(':id', (int) $parametres['id']);
+        if (array_key_exists('login', $parametres)) {
+            $this->queryBuilder->andWhere('login = :login');
+            $this->queryBuilder->setParameter(':login', (int) $parametres['login']);
         }
     }
 

--- a/Makefile
+++ b/Makefile
@@ -11,28 +11,36 @@ define make_version
 	@git tag -a `semver tag` -m "Releasing `semver tag`"
 endef
 
-default : help
+.DEFAULT_GOAL := help
+
+#
+# Thanks to https://blog.theodo.fr/2018/05/why-you-need-a-makefile-on-your-project/
+#
 
 help:
-	@echo 'help'
+	@grep -E '(^[a-zA-Z_-]+:.*?##.*$$)|(^##)' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}{printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
 
-install:
+
+## Installation
+install: ## Installe les dépendances composer
 	php composer.phar install
 
-major:
+## Administration
+major: ## Monte la version majeure du logiciel
 	$(call make_version,major)
 
-minor:
+minor:  ## Monte la version mineure du logiciel
 	$(call make_version,minor)
 
-patch:
+patch:  ## Monte la version patch du logiciel
 	$(call make_version,patch)
 
-test: test-unit test-functional
+## CI
+test: test-unit test-functional ## Lance tous les tests applicatifs
 
 test-unit: ## Lance les tests unitaires
 	Vendor/Bin/atoum -ulr
 
-test-functional:
+test-functional: ## Lance les tests fonctionnels
 	cp Tests/Functionals/_data/database.sqlite Tests/Functionals/_data/current.sqlite
 	Vendor/Bin/codecept run api -f

--- a/Tests/Units/Heure/Repos/ReposEntite.php
+++ b/Tests/Units/Heure/Repos/ReposEntite.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Units\Heure\Repos;
+
+/**
+ * Classe de test de l'entité d'heure de repos
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.8
+ */
+final class ReposEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
+{
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithId()
+    {
+        $id = 58;
+        $commentaire = 'Barry Allen';
+        $commentaireRefus = 'Barry Allen 2';
+
+        $this->newTestedInstance([
+            'id' => $id,
+            'login' => 'Abagnale',
+            'debut' => 1000,
+            'fin' => 1100,
+            'duree' => 10,
+            'type_periode' => 7,
+            'statut' => 10,
+            'commentaire' => $commentaire,
+            'commentaire_refus' => $commentaireRefus,
+        ]);
+
+        $this->assertConstructWithId($this->testedInstance, $id);
+        $this->string($this->testedInstance->getLogin())->isIdenticalTo('Abagnale');
+        $this->integer($this->testedInstance->getDebut())->isIdenticalTo(1000);
+        $this->integer($this->testedInstance->getFin())->isIdenticalTo(1100);
+        $this->integer($this->testedInstance->getTypePeriode())->isIdenticalTo(7);
+        $this->integer($this->testedInstance->getStatut())->isIdenticalTo(10);
+        $this->string($this->testedInstance->getCommentaire())->isIdenticalTo($commentaire);
+        $this->string($this->testedInstance->getCommentaireRefus())->isIdenticalTo($commentaireRefus);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithoutId()
+    {
+        $this->newTestedInstance([
+            'login' => 'Abagnale',
+            'debut' => 1000,
+        ]);
+        $this->variable($this->testedInstance->getId())->isNull();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testReset()
+    {
+        $this->newTestedInstance(['login' => 'Abagnale', 'debut' => 1000,]);
+
+        $this->assertReset($this->testedInstance);
+    }
+}

--- a/Tests/Units/Heure/Repos/ReposEntite.php
+++ b/Tests/Units/Heure/Repos/ReposEntite.php
@@ -36,6 +36,7 @@ final class ReposEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
         $this->string($this->testedInstance->getLogin())->isIdenticalTo('Abagnale');
         $this->integer($this->testedInstance->getDebut())->isIdenticalTo(1000);
         $this->integer($this->testedInstance->getFin())->isIdenticalTo(1100);
+        $this->integer($this->testedInstance->getDuree())->isIdenticalTo(10);
         $this->integer($this->testedInstance->getTypePeriode())->isIdenticalTo(7);
         $this->integer($this->testedInstance->getStatut())->isIdenticalTo(10);
         $this->string($this->testedInstance->getCommentaire())->isIdenticalTo($commentaire);

--- a/Tests/Units/Heure/Repos/ReposRepository.php
+++ b/Tests/Units/Heure/Repos/ReposRepository.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Units\Heure\Repos;
+
+/**
+ * Classe de test du repository de l'heure de repos
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.8
+ */
+final class ReposRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
+{
+    final protected function getStorageContent() : array
+    {
+        return [
+            'id_heure' => 42,
+            'login' => 'Sherlock',
+            'debut' => 7427,
+            'fin' => 4527,
+            'duree' => 78,
+            'type_periode' => 26,
+            'statut' => 3,
+            'comment' => 'Arsène',
+            'comment_refus' => 'Lupin',
+        ];
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+            'login' => 'Watson',
+            'debut' => 77,
+            'fin' => 89432,
+        ];
+    }
+}

--- a/Tools/App.php
+++ b/Tools/App.php
@@ -29,9 +29,10 @@ $app->get('/hello_world', function(IRequest $request, IResponse $response) {
     return $response->withJson('Hi there !');
 });
 
-require_once ROUTE_PATH . DS. 'Absence.php';
+require_once ROUTE_PATH . DS . 'Absence.php';
 require_once ROUTE_PATH . DS . 'Authentification.php';
 require_once ROUTE_PATH . DS . 'Groupe.php';
+require_once ROUTE_PATH . DS . 'Heure.php';
 require_once ROUTE_PATH . DS . 'Journal.php';
 require_once ROUTE_PATH . DS . 'JourFerie.php';
 require_once ROUTE_PATH . DS . 'Planning.php';

--- a/Tools/Controllers/HeureReposEmployeController.php
+++ b/Tools/Controllers/HeureReposEmployeController.php
@@ -8,14 +8,14 @@ use \Slim\Interfaces\RouterInterface as IRouter;
 use LibertAPI\Heure\Repos;
 
 /**
- * Contrôleur des heures de repos
+ * Contrôleur des heures de repos de l'employé courant
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina
  *
  * @since 1.8
  */
-final class HeureReposUtilisateurController extends \LibertAPI\Tools\Libraries\AController
+final class HeureReposEmployeController extends \LibertAPI\Tools\Libraries\AController
 implements Interfaces\IGetable
 {
     public function __construct(Repos\ReposRepository $repository, IRouter $router)
@@ -28,6 +28,7 @@ implements Interfaces\IGetable
      */
     public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
     {
+        unset($arguments);
         return $this->getList($request, $response);
     }
 
@@ -36,10 +37,10 @@ implements Interfaces\IGetable
      */
     private function getList(IRequest $request, IResponse $response) : IResponse
     {
+        $user = $request->getAttribute('currentUser');
+        $arguments = array_merge($request->getQueryParams(), ['login' => $user->getLogin()]);
         try {
-            $responseResources = $this->repository->getList(
-                $request->getQueryParams()
-            );
+            $responseResources = $this->repository->getList($arguments);
         } catch (\UnexpectedValueException $e) {
             return $this->getResponseNoContent($response);
         } catch (\Exception $e) {

--- a/Tools/Controllers/HeureReposUtilisateurController.php
+++ b/Tools/Controllers/HeureReposUtilisateurController.php
@@ -59,19 +59,13 @@ implements Interfaces\IGetable
         return [
             'id' => $entite->getId(),
             'login' => $entite->getLogin(),
-            'dateDebut' => $entite->getDateDebut(),
-            'demiJourneeDebut' => $entite->getDemiJourneeDebut(),
-            'dateFin' => $entite->getDateFin(),
-            'demiJourneeFin' => $entite->getDemiJourneeFin(),
-            'nombreJours' => $entite->getNombreJours(),
-            'type' => $entite->getType(),
-            'etat' => $entite->getEtat(),
-            'editionId' => $entite->getEditionId(),
-            'motifRefus' => $entite->getMotifRefus(),
-            'dateDemande' => $entite->getDateDemande(),
-            'dateTraitement' => $entite->getDateTraitement(),
-            'fermetureId' => $entite->getFermetureId(),
-            'num' => $entite->getNum(),
+            'debut' => $entite->getDebut(),
+            'fin' => $entite->getFin(),
+            'duree' => $entite->getDuree(),
+            'type_periode' => $entite->getTypePeriode(),
+            'statut' => $entite->getStatut(),
+            'commentaire' => $entite->getCommentaire(),
+            'commentaire_refus' => $entite->getCommentaireRefus(),
         ];
     }
 }

--- a/Tools/Controllers/HeureReposUtilisateurController.php
+++ b/Tools/Controllers/HeureReposUtilisateurController.php
@@ -5,7 +5,7 @@ use LibertAPI\Tools\Interfaces;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
 use \Slim\Interfaces\RouterInterface as IRouter;
-use LibertAPI\Absence\Periode;
+use LibertAPI\Heure\Repos;
 
 /**
  * Contrôleur des heures de repos
@@ -18,12 +18,10 @@ use LibertAPI\Absence\Periode;
 final class HeureReposUtilisateurController extends \LibertAPI\Tools\Libraries\AController
 implements Interfaces\IGetable
 {
-    public function __construct(Periode\PeriodeRepository $repository, IRouter $router)
+    public function __construct(Repos\ReposRepository $repository, IRouter $router)
     {
         parent::__construct($repository, $router);
     }
-
-    
 
     /**
      * {@inheritDoc}
@@ -34,14 +32,10 @@ implements Interfaces\IGetable
     }
 
     /**
-     * Retourne un tableau de période d'absence
+     * Retourne un tableau d'heures de repos
      *
-     * @param IRequest $request Requête Http
-     * @param IResponse $response Réponse Http
-     *
-     * @return IResponse
      */
-    private function getList(IRequest $request, IResponse $response)
+    private function getList(IRequest $request, IResponse $response) : IResponse
     {
         try {
             $responseResources = $this->repository->getList(
@@ -59,12 +53,8 @@ implements Interfaces\IGetable
 
     /**
      * Construit le « data » du json
-     *
-     * @param Periode\PeriodeEntite $entite Période
-     *
-     * @return array
      */
-    private function buildData(Periode\PeriodeEntite $entite)
+    private function buildData(Repos\ReposEntite $entite) : array
     {
         return [
             'id' => $entite->getId(),

--- a/Tools/Controllers/HeureReposUtilisateurController.php
+++ b/Tools/Controllers/HeureReposUtilisateurController.php
@@ -33,7 +33,6 @@ implements Interfaces\IGetable
 
     /**
      * Retourne un tableau d'heures de repos
-     *
      */
     private function getList(IRequest $request, IResponse $response) : IResponse
     {

--- a/Tools/Controllers/HeureReposUtilisateurController.php
+++ b/Tools/Controllers/HeureReposUtilisateurController.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tools\Controllers;
+
+use LibertAPI\Tools\Interfaces;
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+use \Slim\Interfaces\RouterInterface as IRouter;
+use LibertAPI\Absence\Periode;
+
+/**
+ * Contrôleur des heures de repos
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 1.8
+ */
+final class HeureReposUtilisateurController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable
+{
+    public function __construct(Periode\PeriodeRepository $repository, IRouter $router)
+    {
+        parent::__construct($repository, $router);
+    }
+
+    
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
+    {
+        return $this->getList($request, $response);
+    }
+
+    /**
+     * Retourne un tableau de période d'absence
+     *
+     * @param IRequest $request Requête Http
+     * @param IResponse $response Réponse Http
+     *
+     * @return IResponse
+     */
+    private function getList(IRequest $request, IResponse $response)
+    {
+        try {
+            $responseResources = $this->repository->getList(
+                $request->getQueryParams()
+            );
+        } catch (\UnexpectedValueException $e) {
+            return $this->getResponseNoContent($response);
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+        $entites = array_map([$this, 'buildData'], $responseResources);
+
+        return $this->getResponseSuccess($response, $entites, 200);
+    }
+
+    /**
+     * Construit le « data » du json
+     *
+     * @param Periode\PeriodeEntite $entite Période
+     *
+     * @return array
+     */
+    private function buildData(Periode\PeriodeEntite $entite)
+    {
+        return [
+            'id' => $entite->getId(),
+            'login' => $entite->getLogin(),
+            'dateDebut' => $entite->getDateDebut(),
+            'demiJourneeDebut' => $entite->getDemiJourneeDebut(),
+            'dateFin' => $entite->getDateFin(),
+            'demiJourneeFin' => $entite->getDemiJourneeFin(),
+            'nombreJours' => $entite->getNombreJours(),
+            'type' => $entite->getType(),
+            'etat' => $entite->getEtat(),
+            'editionId' => $entite->getEditionId(),
+            'motifRefus' => $entite->getMotifRefus(),
+            'dateDemande' => $entite->getDateDemande(),
+            'dateTraitement' => $entite->getDateTraitement(),
+            'fermetureId' => $entite->getFermetureId(),
+            'num' => $entite->getNum(),
+        ];
+    }
+}

--- a/Tools/Middlewares/AccessChecker.php
+++ b/Tools/Middlewares/AccessChecker.php
@@ -26,7 +26,7 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
             case 'Authentification':
             case 'HelloWorld':
             case 'Planning|Creneau':
-            case 'Heure|Repos|Utilisateur|Me':
+            case 'Employe|Me|Heure|Repos':
                 return $next($request, $response);
             case 'Groupe':
             case 'Groupe|GrandResponsable':

--- a/Tools/Middlewares/AccessChecker.php
+++ b/Tools/Middlewares/AccessChecker.php
@@ -18,20 +18,19 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
         $container = $this->getContainer();
 
         switch ($ressourcePath) {
-            case 'Absence|Type':
             case 'Absence|Periode':
-            case 'Utilisateur':
-            case 'JourFerie':
-            case 'Journal':
+            case 'Absence|Type':
             case 'Authentification':
-            case 'HelloWorld':
-            case 'Planning|Creneau':
             case 'Employe|Me|Heure|Repos':
+            case 'HelloWorld':
+            case 'Journal':
+            case 'Planning|Creneau':
+            case 'Utilisateur':
                 return $next($request, $response);
             case 'Groupe':
+            case 'Groupe|Employe':
             case 'Groupe|GrandResponsable':
             case 'Groupe|Responsable':
-            case 'Groupe|Employe':
                 $user = $request->getAttribute('currentUser');
                 if (!$user->isAdmin()) {
                     return call_user_func(

--- a/Tools/Middlewares/AccessChecker.php
+++ b/Tools/Middlewares/AccessChecker.php
@@ -32,7 +32,7 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
             case 'Groupe|GrandResponsable':
             case 'Groupe|Responsable':
             case 'Groupe|Employe':
-                $user = $container->get('currentUser');
+                $user = $request->getAttribute('currentUser');
                 if (!$user->isAdmin()) {
                     return call_user_func(
                         $container->get('forbiddenHandler'),
@@ -43,7 +43,7 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
 
                 return $next($request, $response);
             case 'JourFerie':
-                $user = $container->get('currentUser');
+                $user = $request->getAttribute('currentUser');
                 if (!$user->isHautResponsable()) {
                     return call_user_func(
                         $container->get('forbiddenHandler'),
@@ -54,7 +54,7 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
 
                 return $next($request, $response);
             case 'Planning':
-                $user = $container->get('currentUser');
+                $user = $request->getAttribute('currentUser');
                 if (!$user->isResponsable() && !$user->isHautResponsable() && !$user->isAdmin()) {
                     return call_user_func(
                         $container->get('forbiddenHandler'),

--- a/Tools/Middlewares/AccessChecker.php
+++ b/Tools/Middlewares/AccessChecker.php
@@ -26,6 +26,7 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
             case 'Authentification':
             case 'HelloWorld':
             case 'Planning|Creneau':
+            case 'Heure|Repos|Utilisateur|Me':
                 return $next($request, $response);
             case 'Groupe':
             case 'Groupe|GrandResponsable':

--- a/Tools/Middlewares/Identificator.php
+++ b/Tools/Middlewares/Identificator.php
@@ -26,8 +26,8 @@ final class Identificator extends \LibertAPI\Tools\AMiddleware
         } elseif ($this->isIdentificationOK($request, $repoUtilisateur)) {
              // Ping de last_access
             $utilisateur = $repoUtilisateur->updateDateLastAccess($this->utilisateur);
+            $request = $request->withAttribute('currentUser', $utilisateur);
 
-            $container->set('currentUser', $utilisateur);
             return $next($request, $response);
         }
 

--- a/Tools/Route/Absence.php
+++ b/Tools/Route/Absence.php
@@ -30,6 +30,5 @@ $app->group('/absence', function () {
         $this->get('/{periodeId:[0-9]+}', [AbsencePeriodeController::class, 'get'])->setName('getAbsencePeriodeDetail');
         /* Collection */
         $this->get('', [AbsencePeriodeController::class, 'get'])->setName('getAbsencePeriodeListe');
-
     });
 });

--- a/Tools/Route/Heure.php
+++ b/Tools/Route/Heure.php
@@ -10,14 +10,17 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  * La convention de nommage est de mettre les routes au singulier
  */
 
+// Ce sont des routes sur l'heure, oui, mais l'association est à l'envers : je veux les heures qui ME sont associées. C'est donc /employe/me/heure_repos
+// Dans tous les cas, c'est une bonne pratique de transmettre l'utilisateur courant dans le controleur
+
 /* Routes sur l'heure */
 $app->group('/heure', function () {
     $this->group('/repos', function () {
-        $this->get('/utilisateur/me', function (IRequest $request, IResponse $response, array $args) {
+        $this->get('/employe/me', function (IRequest $request, IResponse $response, array $args) {
             $args = array_merge($args, ['currentUser' => $this->get('currentUser')]);
 
             // @TODO: Voir s'il s'agit de la meilleure méthode, vis à vis du métier
-            return $this->get(HeureReposUtilisateurController::class)->get($request, $response, $args);
+            return $this->get(HeureReposEmployeController::class)->get($request, $response, $args);
         })->setName('getHeureReposUtilisateurMeListe');
     });
 });

--- a/Tools/Route/Heure.php
+++ b/Tools/Route/Heure.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+use LibertAPI\Tools\Controllers\HeureReposUtilisateurController;
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+
+/*
+ * Doit être importé après la création de $app. Ne créé rien.
+ *
+ * La convention de nommage est de mettre les routes au singulier
+ */
+
+/* Routes sur l'heure */
+$app->group('/heure', function () {
+    $this->group('/repos', function () {
+        $this->get('/utilisateur/me', function (IRequest $request, IResponse $response, array $args) {
+            $args = array_merge($args, ['currentUser' => $this->get('currentUser')]);
+            
+            return $this->get(HeureReposUtilisateurController::class)->get($request, $response, $args);
+        })->setName('getHeureReposUtilisateurMeListe');
+    });
+});

--- a/Tools/Route/Heure.php
+++ b/Tools/Route/Heure.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
-use LibertAPI\Tools\Controllers\HeureReposUtilisateurController;
+use LibertAPI\Tools\Controllers\HeureReposEmployeController;
 use Psr\Http\Message\ServerRequestInterface as IRequest;
 use Psr\Http\Message\ResponseInterface as IResponse;
 
@@ -14,8 +14,4 @@ use Psr\Http\Message\ResponseInterface as IResponse;
 // Dans tous les cas, c'est une bonne pratique de transmettre l'utilisateur courant dans le controleur
 
 /* Routes sur l'heure */
-$app->group('/heure', function () {
-    $this->group('/repos', function () {
-        $this->get('/employe/me', [HeureReposEmployeController::class, 'get'])->setName('getHeureReposUtilisateurMeListe');
-    });
-});
+$app->get('/employe/me/heure/repos', [HeureReposEmployeController::class, 'get'])->setName('getHeureReposEmployeMeListe');

--- a/Tools/Route/Heure.php
+++ b/Tools/Route/Heure.php
@@ -10,8 +10,5 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  * La convention de nommage est de mettre les routes au singulier
  */
 
-// Ce sont des routes sur l'heure, oui, mais l'association est à l'envers : je veux les heures qui ME sont associées. C'est donc /employe/me/heure_repos
-// Dans tous les cas, c'est une bonne pratique de transmettre l'utilisateur courant dans le controleur
-
 /* Routes sur l'heure */
 $app->get('/employe/me/heure/repos', [HeureReposEmployeController::class, 'get'])->setName('getHeureReposEmployeMeListe');

--- a/Tools/Route/Heure.php
+++ b/Tools/Route/Heure.php
@@ -15,7 +15,8 @@ $app->group('/heure', function () {
     $this->group('/repos', function () {
         $this->get('/utilisateur/me', function (IRequest $request, IResponse $response, array $args) {
             $args = array_merge($args, ['currentUser' => $this->get('currentUser')]);
-            
+
+            // @TODO: Voir s'il s'agit de la meilleure méthode, vis à vis du métier
             return $this->get(HeureReposUtilisateurController::class)->get($request, $response, $args);
         })->setName('getHeureReposUtilisateurMeListe');
     });

--- a/Tools/Route/Heure.php
+++ b/Tools/Route/Heure.php
@@ -16,11 +16,6 @@ use Psr\Http\Message\ResponseInterface as IResponse;
 /* Routes sur l'heure */
 $app->group('/heure', function () {
     $this->group('/repos', function () {
-        $this->get('/employe/me', function (IRequest $request, IResponse $response, array $args) {
-            $args = array_merge($args, ['currentUser' => $this->get('currentUser')]);
-
-            // @TODO: Voir s'il s'agit de la meilleure méthode, vis à vis du métier
-            return $this->get(HeureReposEmployeController::class)->get($request, $response, $args);
-        })->setName('getHeureReposUtilisateurMeListe');
+        $this->get('/employe/me', [HeureReposEmployeController::class, 'get'])->setName('getHeureReposUtilisateurMeListe');
     });
 });

--- a/decisions.md
+++ b/decisions.md
@@ -1,5 +1,6 @@
 # 2019-04-06
 * Il me paraît naturel sémantiquement d'avoir l'utilisateur courant dans la request, je l'y place donc.
+* Nous commençons la création des routes `employe/me/[ressources]` qui fournit des opérations automatiquement filtrées sur l'utilisateur courant. La convention est de décrire ces routes dans le fichier dédié à la ressource (ie. `employe/me/heure/repos` dans `/Tools/Route/Heure.php`).
 
 ~ Prytoegrian
 

--- a/decisions.md
+++ b/decisions.md
@@ -1,15 +1,22 @@
+# 2019-04-06
+* Il me paraît naturel sémantiquement d'avoir l'utilisateur courant dans la request, je l'y place donc.
+
+~ Prytoegrian
+
 # 2018-12-17
-* Afin de mieux coller aux résultats de `__DIR__` et `dirname()`, je supprime toutes les slashes finaux des constantes `*_PATH`
+* Afin de mieux coller aux résultats de `__DIR__` et `dirname()`, je supprime tous les slashes finaux des constantes `*_PATH`
+
+~ Prytoegrian
 
 # 2018-10-20
 * Il y a de multiples méthodes de connexion à l'application « libertempo » et l'API commence à les absorber petit à petit. Naturellement, j'ai souhaité que cette diversité de connecteurs soit transparente pour la plus grande partie de l'appli possible. J'ai donc mis en place une Fabrique pour que cette dernière fasse seule le choix du connecteur à sélectionner, ses consommateurs manipulant un contrat.
-* À cet effet, le contrôleur d'authentification n'est plus testable unitairement (le statiqu l'en empêche). Je souhaiterais ne pas rester sur un échec et tester cette partie d'une autre manière.
-* Pour conserver la séparation stricte entre newable et injectable, j'ai de plus muté la Request serveur pour qu'elle contienne la configuration LDAP ; je ne suis pas trop fan de la solution et aimerait trouver une approche plus élégante et pérenne.
+* À cet effet, le contrôleur d'authentification n'est plus testable unitairement (le static l'en empêche). Je souhaiterais ne pas rester sur un échec et tester cette partie d'une autre manière.
+* Pour conserver la séparation stricte entre newable et injectable, j'ai de plus muté la Request serveur pour qu'elle contienne la configuration LDAP ; je ne suis pas trop fan de la solution et aimerais trouver une approche plus élégante et pérenne.
 
 ~ Prytoegrian
 
 ## 2018-06-07
-* J'ai désormais appliqué le paradigme « package by components » attendu que le « package by feature » soulevait des embûches. En effet, le contrôleur ne fait pas parti d'un composant, il est un moyen d'accès vers lui ; je l'ai donc déplacé dans `Tools`. À l'exception des répertoires d'utilitaires, nous aurons ainsi une vision claire des objectifs du logiciel du premier coup d'œil et une place toute trouvée pour les structures applicatives relatives au différents métiers du soft.
+* J'ai désormais appliqué le paradigme « package by components » attendu que le « package by feature » soulevait des embûches. En effet, le contrôleur ne fait pas partie d'un composant, il est un moyen d'accès vers lui ; je l'ai donc déplacé dans `Tools`. À l'exception des répertoires d'utilitaires, nous aurons ainsi une vision claire des objectifs du logiciel du premier coup d'œil et une place toute trouvée pour les structures applicatives relatives au différents métiers du soft.
 * Un framework d'injection de dépendances a également fait son entrée. Il nous aidera à supprimer tout un pan de verbosité, facilite le test et nous permettra d'exprimer le plus précisément possible les interactions entre les structures applicatives.
 * Le problème des relations N-N n'en est pas encore un. Pour le moment, j'ai créé des entités pour les représentants de ces associations que l'on utilisera côté client. Si besoin il y a, nous créerons des Aggrégats.
 


### PR DESCRIPTION
Cf. #10 

Ajout des heures de repos de l'employé courant, tests unitaires compris. La route désormais dispo est  : 
* GET `/employe/me/heure/repos `

Après mûre réflexion, je ne vois pas de mauvaise pratique à ce que l'utilisateur courant soit embarqué dans la request, je l'y place donc pour qu'il soit consommé là où c'est nécessaire. Ici en tant que prédicat de filtre automatique de la récolte des heures, à terme dans d'autres routes `/me`.


Comme à mon habitude, j'en ai profité pour améliorer le makefile.