### PR TITLE
Solde de l'employé en cours

### DIFF
--- a/Solde/SoldeEntite.php
+++ b/Solde/SoldeEntite.php
@@ -60,7 +60,7 @@ class SoldeEntite extends \LibertAPI\Tools\Libraries\AEntite
     /**
      * Retourne la donnée la plus à jour du champ su_reliquat
      */
-    public function getReliquat() : string
+    public function getReliquat() : float
     {
         return $this->getFreshData('reliquat');
     }

--- a/Solde/SoldeEntite.php
+++ b/Solde/SoldeEntite.php
@@ -18,6 +18,14 @@ use LibertAPI\Tools\Exceptions\MissingArgumentException;
 class SoldeEntite extends \LibertAPI\Tools\Libraries\AEntite
 {
     /**
+     * Retourne la donnée la plus à jour du champ id (==login)
+     */
+    final protected function setId($id)
+    {
+        $this->id = (string) $id;
+    }
+
+    /**
      * Retourne la donnée la plus à jour du champ login
      */
     public function getLogin() : string

--- a/Solde/SoldeEntite.php
+++ b/Solde/SoldeEntite.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Solde;
+
+use LibertAPI\Tools\Exceptions\MissingArgumentException;
+
+/**
+ * @inheritDoc
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina <wouldsmina@gmail.com>
+ *
+ * @since 1.9
+ * @see \LibertAPI\Tests\Units\Solde\SoldeEntite
+ *
+ * Ne devrait être contacté que par SoldeRepository
+ * Ne devrait contacter personne
+ */
+class SoldeEntite extends \LibertAPI\Tools\Libraries\AEntite
+{
+    /**
+     * Retourne la donnée la plus à jour du champ login
+     */
+    public function getLogin() : string
+    {
+        return $this->getFreshData('login');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ su_abs_id
+     */
+    public function getTypeAbsence() : int
+    {
+        return $this->getFreshData('type_absence');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ su_nb_an
+     */
+    public function getSoldeAn() : float
+    {
+        return $this->getFreshData('solde_annuel');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ su_solde
+     */
+    public function getSolde() : float
+    {
+        return $this->getFreshData('solde');
+    }
+
+    /**
+     * Retourne la donnée la plus à jour du champ su_reliquat
+     */
+    public function getReliquat() : string
+    {
+        return $this->getFreshData('reliquat');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function populate(array $data)
+    {
+    }
+}

--- a/Solde/SoldeRepository.php
+++ b/Solde/SoldeRepository.php
@@ -19,7 +19,7 @@ class SoldeRepository extends \LibertAPI\Tools\Libraries\ARepository
 {
     final protected function getEntiteClass() : string
     {
-        return CongeEntite::class;
+        return SoldeEntite::class;
     }
 
     /**
@@ -41,6 +41,7 @@ class SoldeRepository extends \LibertAPI\Tools\Libraries\ARepository
     final protected function getStorage2Entite(array $dataStorage)
     {
         return [
+            'id' => $dataStorage['su_login'],
             'login' => $dataStorage['su_login'],
             'type_absence' => (int) $dataStorage['su_abs_id'],
             'solde_annuel' => (int) $dataStorage['su_nb_an'],

--- a/Solde/SoldeRepository.php
+++ b/Solde/SoldeRepository.php
@@ -69,7 +69,7 @@ class SoldeRepository extends \LibertAPI\Tools\Libraries\ARepository
     final protected function setWhere(array $parametres)
     {
         if (array_key_exists('login', $parametres)) {
-            $this->queryBuilder->andWhere('login = :login');
+            $this->queryBuilder->andWhere('su_login = :login');
             $this->queryBuilder->setParameter(':login', $parametres['login']);
         }
     }

--- a/Solde/SoldeRepository.php
+++ b/Solde/SoldeRepository.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Solde;
+
+use LibertAPI\Tools\Libraries\AEntite;
+
+/**
+ * {@inheritDoc}
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina <wouldsmina@gmail.com>
+ *
+ * @since 1.9
+ * @see \LibertAPI\Tests\Units\SoldeRepository
+ *
+ * Ne devrait être contacté que par le SoldeEmployeController
+ * Ne devrait contacter que SoldeEntite
+ */
+class SoldeRepository extends \LibertAPI\Tools\Libraries\ARepository
+{
+    final protected function getEntiteClass() : string
+    {
+        return CongeEntite::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getParamsConsumer2Storage(array $paramsConsumer) : array
+    {
+        $results = [];
+        if (array_key_exists('login', $paramsConsumer)) {
+            $results['login'] = (string) $paramsConsumer['login'];
+        }
+
+        return $results;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getStorage2Entite(array $dataStorage)
+    {
+        return [
+            'login' => $dataStorage['su_login'],
+            'type_absence' => (int) $dataStorage['su_abs_id'],
+            'solde_annuel' => (int) $dataStorage['su_nb_an'],
+            'solde' => $dataStorage['su_solde'],
+            'reliquat' => $dataStorage['su_reliquat'],
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function setValues(array $values)
+    {
+        unset($values);
+    }
+
+    final protected function setSet(array $parametres)
+    {
+        unset($parametres);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function setWhere(array $parametres)
+    {
+        if (array_key_exists('login', $parametres)) {
+            $this->queryBuilder->andWhere('login = :login');
+            $this->queryBuilder->setParameter(':login', $parametres['login']);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getEntite2Storage(AEntite $entite) : array
+    {
+        unset($entite);
+        return [];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    final protected function getTableName() : string
+    {
+        return 'conges_solde_user';
+    }
+}

--- a/Solde/SoldeRepository.php
+++ b/Solde/SoldeRepository.php
@@ -45,8 +45,8 @@ class SoldeRepository extends \LibertAPI\Tools\Libraries\ARepository
             'login' => $dataStorage['su_login'],
             'type_absence' => (int) $dataStorage['su_abs_id'],
             'solde_annuel' => (int) $dataStorage['su_nb_an'],
-            'solde' => $dataStorage['su_solde'],
-            'reliquat' => $dataStorage['su_reliquat'],
+            'solde' => (float) $dataStorage['su_solde'],
+            'reliquat' => (float) $dataStorage['su_reliquat'],
         ];
     }
 

--- a/Tests/Functionals/SoldeCest.php
+++ b/Tests/Functionals/SoldeCest.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Functionals;
+
+class SoldeCest extends BaseTestCest
+{
+    public function testListe(\ApiTester $i)
+    {
+        $i->sendGET('/employe/me/solde');
+
+        $this->seeResponseOK($i);
+    }
+}

--- a/Tests/Units/Solde/SoldeEntite.php
+++ b/Tests/Units/Solde/SoldeEntite.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types = 1);
 namespace LibertAPI\Tests\Units\Solde;
 
+use \LibertAPI\Solde\SoldeEntite as _Entite;
+
 /**
  * Classe de test de l'entité d'heure de Additionnelle
  *
@@ -16,22 +18,10 @@ final class SoldeEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
      */
     public function testConstructWithId()
     {
+        $id = 'octavia';
+        $entite = new _Entite(['id' => $id]);
 
-        $this->newTestedInstance([
-            'id' => 'octavia',
-            'login' => 'octavia',
-            'type_absence' => 1,
-            'solde_annuel' => 100,
-            'solde' => 10.5,
-            'reliquat' => 7.5,
-        ]);
-
-        $this->assertConstructWithId($this->testedInstance, 'octavia');
-        $this->string($this->testedInstance->getLogin())->isIdenticalTo('octavia');
-        $this->integer($this->testedInstance->getTypeAbsence())->isIdenticalTo(1);
-        $this->integer($this->testedInstance->getSoldeAn())->isIdenticalTo(100);
-        $this->integer($this->testedInstance->getSolde())->isIdenticalTo(10.5);
-        $this->integer($this->testedInstance->getReliquat())->isIdenticalTo(7.5);
+        $this->string($entite->getId())->isIdenticalTo($id);
     }
 
     /**

--- a/Tests/Units/Solde/SoldeEntite.php
+++ b/Tests/Units/Solde/SoldeEntite.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Units\Solde;
+
+/**
+ * Classe de test de l'entité d'heure de Additionnelle
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina <wouldsmina@gmail.com>
+ *
+ * @since 1.9
+ */
+final class SoldeEntite extends \LibertAPI\Tests\Units\Tools\Libraries\AEntite
+{
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithId()
+    {
+
+        $this->newTestedInstance([
+            'id' => 'octavia',
+            'login' => 'octavia',
+            'type_absence' => 1,
+            'solde_annuel' => 100,
+            'solde' => 10.5,
+            'reliquat' => 7.5,
+        ]);
+
+        $this->assertConstructWithId($this->testedInstance, 'octavia');
+        $this->string($this->testedInstance->getLogin())->isIdenticalTo('octavia');
+        $this->integer($this->testedInstance->getTypeAbsence())->isIdenticalTo(1);
+        $this->integer($this->testedInstance->getSoldeAn())->isIdenticalTo(100);
+        $this->integer($this->testedInstance->getSolde())->isIdenticalTo(10.5);
+        $this->integer($this->testedInstance->getReliquat())->isIdenticalTo(7.5);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testConstructWithoutId()
+    {
+        $this->newTestedInstance([
+            'type_absence' => 1,
+            'solde_annuel' => 100,
+            'solde' => 10.5,
+            'reliquat' => 7.5,
+        ]);
+        $this->variable($this->testedInstance->getId())->isNull();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function testReset()
+    {
+        $this->newTestedInstance(['login' => 'octavia', 'type_absence' => 1,]);
+
+        $this->assertReset($this->testedInstance);
+    }
+}

--- a/Tests/Units/Solde/SoldeEntite.php
+++ b/Tests/Units/Solde/SoldeEntite.php
@@ -4,7 +4,7 @@ namespace LibertAPI\Tests\Units\Solde;
 use \LibertAPI\Solde\SoldeEntite as _Entite;
 
 /**
- * Classe de test de l'entité d'heure de Additionnelle
+ * Classe de test de l'entité de solde
  *
  * @author Prytoegrian <prytoegrian@protonmail.com>
  * @author Wouldsmina <wouldsmina@gmail.com>

--- a/Tests/Units/Solde/SoldeRepository.php
+++ b/Tests/Units/Solde/SoldeRepository.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tests\Units\Solde;
+
+/**
+ * Classe de test du repository du solde
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina <wouldsmina@gmail.com>
+ *
+ * @since 1.9
+ */
+final class SoldeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepository
+{
+    final protected function getStorageContent() : array
+    {
+        return [
+            'id' => 'bellamy',
+            'su_login' => 'bellamy',
+            'su_abs_id' => 2,
+            'su_nb_an' => 100,
+            'su_solde' => 10.5,
+            'su_reliquat' => 1.5,
+        ];
+    }
+
+    protected function getConsumerContent() : array
+    {
+        return [
+            'login' => 'blake',
+            'type_absence' => 2,
+        ];
+    }
+}

--- a/Tools/App.php
+++ b/Tools/App.php
@@ -33,6 +33,7 @@ require_once ROUTE_PATH . DS . 'Absence.php';
 require_once ROUTE_PATH . DS . 'Authentification.php';
 require_once ROUTE_PATH . DS . 'Groupe.php';
 require_once ROUTE_PATH . DS . 'Heure.php';
+require_once ROUTE_PATH . DS . 'Solde.php';
 require_once ROUTE_PATH . DS . 'Journal.php';
 require_once ROUTE_PATH . DS . 'JourFerie.php';
 require_once ROUTE_PATH . DS . 'Planning.php';

--- a/Tools/Controllers/SoldeEmployeController.php
+++ b/Tools/Controllers/SoldeEmployeController.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tools\Controllers;
+
+use LibertAPI\Tools\Interfaces;
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+use \Slim\Interfaces\RouterInterface as IRouter;
+use LibertAPI\Solde;
+
+/**
+ * Contrôleur du solde de l'employé courant
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina <wouldsmina@gmail.com>
+ *
+ * @since 1.9
+ */
+final class SoldeEmployeController extends \LibertAPI\Tools\Libraries\AController
+implements Interfaces\IGetable
+{
+    public function __construct(Solde\SoldeRepository $repository, IRouter $router)
+    {
+        parent::__construct($repository, $router);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
+    {
+        unset($arguments);
+        return $this->getList($request, $response);
+    }
+
+    /**
+     * Retourne un tableau des soldes
+     */
+    private function getList(IRequest $request, IResponse $response) : IResponse
+    {
+        $user = $request->getAttribute('currentUser');
+        $arguments = array_merge($request->getQueryParams(), ['login' => $user->getLogin()]);
+        try {
+            $responseResources = $this->repository->getList($arguments);
+        } catch (\UnexpectedValueException $e) {
+            return $this->getResponseNoContent($response);
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+        $entites = array_map([$this, 'buildData'], $responseResources);
+
+        return $this->getResponseSuccess($response, $entites, 200);
+    }
+
+    /**
+     * Construit le « data » du json
+     */
+    private function buildData(Solde\SoldeEntite $entite) : array
+    {
+        return [
+            'login' => $entite->getLogin(),
+            'type_absence' => $entite->getTypeAbsence(),
+            'solde_annuel' => $entite->getSoldeAn(),
+            'solde' => $entite->getSolde(),
+            'reliquat' => $entite->getReliquat(),
+        ];
+    }
+}

--- a/Tools/Middlewares/AccessChecker.php
+++ b/Tools/Middlewares/AccessChecker.php
@@ -23,6 +23,7 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
             case 'Authentification':
             case 'Employe|Me|Heure|Repos':
             case 'Employe|Me|Heure|Additionnelle':
+            case 'Employe|Me|Solde':
             case 'HelloWorld':
             case 'Journal':
             case 'Planning|Creneau':

--- a/Tools/Route/Heure.php
+++ b/Tools/Route/Heure.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\ResponseInterface as IResponse;
  */
 
 /* Routes sur l'heure */
-$app->group('/employe/me/heure/', function () {
+$app->group('/employe/me/heure', function () {
     $this->group('/repos', function () {
         $this->get('', [HeureReposEmployeController::class, 'get'])->setName('getHeureReposEmployeMeListe');
     });

--- a/Tools/Route/Solde.php
+++ b/Tools/Route/Solde.php
@@ -9,7 +9,4 @@ use LibertAPI\Tools\Controllers\SoldeEmployeController;
  */
 
 /* Routes sur le solde */
-$app->group('/solde', function () {
-    /* Collection */
-    $this->get('', [SoldeEmployeController::class, 'get'])->setName('getSoldeEmployeMeListe');
-});
+$app->get('/employe/me/solde', [SoldeController::class, 'get'])->setName('getSoldeEmployeMeListe');

--- a/Tools/Route/Solde.php
+++ b/Tools/Route/Solde.php
@@ -9,4 +9,4 @@ use LibertAPI\Tools\Controllers\SoldeEmployeController;
  */
 
 /* Routes sur le solde */
-$app->get('/employe/me/solde', [SoldeController::class, 'get'])->setName('getSoldeEmployeMeListe');
+$app->get('/employe/me/solde', [SoldeEmployeController::class, 'get'])->setName('getSoldeEmployeMeListe');

--- a/Tools/Route/Solde.php
+++ b/Tools/Route/Solde.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+use LibertAPI\Tools\Controllers\SoldeEmployeController;
+
+/*
+ * Doit être importé après la création de $app. Ne créé rien.
+ *
+ * La convention de nommage est de mettre les routes au singulier
+ */
+
+/* Routes sur le solde */
+$app->group('/solde', function () {
+    /* Collection */
+    $this->get('', [SoldeEmployeController::class, 'get'])->setName('getSoldeEmployeMeListe');
+});


### PR DESCRIPTION
Petite PR pour obtenir le solde de l'employé connecté. Route : `/employe/me/solde`

Le test consiste simplement à s'assurer que la requête retourne le solde de chaque type de congé de l'employé.