### PR TITLE
route employe/me

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
-:minor: 10
+:minor: 9
 :patch: 0
 :special: ''
 :metadata: ''

--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 1
-:minor: 9
+:minor: 10
 :patch: 0
 :special: ''
 :metadata: ''

--- a/Tools/Controllers/UtilisateurEmployeController.php
+++ b/Tools/Controllers/UtilisateurEmployeController.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types = 1);
+namespace LibertAPI\Tools\Controllers;
+
+use Psr\Http\Message\ServerRequestInterface as IRequest;
+use Psr\Http\Message\ResponseInterface as IResponse;
+use \Slim\Interfaces\RouterInterface as IRouter;
+use LibertAPI\Utilisateur;
+use LibertAPI\Tools\Exceptions\UnknownResourceException;
+
+
+/**
+ * Contrôleur d'utilisateurs
+ *
+ * @author Prytoegrian <prytoegrian@protonmail.com>
+ * @author Wouldsmina
+ *
+ * @since 0.4
+ * @see \LibertAPI\Utilisateur\UtilisateurController
+ *
+ * Ne devrait être contacté que par le routeur
+ * Ne devrait contacter que le Utilisateur\Repository
+ */
+final class UtilisateurEmployeController extends \LibertAPI\Tools\Libraries\AController
+{
+    public function __construct(Utilisateur\UtilisateurRepository $repository, IRouter $router)
+    {
+        parent::__construct($repository, $router);
+    }
+
+    /*************************************************
+     * GET
+     *************************************************/
+
+    /* Mettre le niveau de droits autorisés
+        && ce que ces droits permettre de voir (l'utilisateur peut-il voir HR / admin ?)
+     */
+
+     /**
+      * {@inheritDoc}
+      */
+    public function get(IRequest $request, IResponse $response, array $arguments) : IResponse
+    {
+        unset($arguments);
+
+        return $this->getOne($request, $response);
+    }
+
+    /**
+     * Retourne un élément unique
+     *
+     * @param IResponse $response Réponse Http
+     * @param int $id ID de l'élément
+     *
+     * @return IResponse, 404 si l'élément n'est pas trouvé, 200 sinon
+     */
+    private function getOne(IRequest $request, IResponse $response) : IResponse
+    {
+        $id = $request->getAttribute('currentUser')->getLogin();
+        try {
+            $utilisateur = $this->repository->getOne($id);
+        } catch (UnknownResourceException $e) {
+            return $this->getResponseNotFound($response, 'Element « utilisateurs#' . $id . ' » is not a valid resource');
+        } catch (\Exception $e) {
+            return $this->getResponseError($response, $e);
+        }
+
+        return $this->getResponseSuccess(
+            $response,
+            $this->buildData($utilisateur),
+            200
+        );
+    }
+
+    /**
+     * Construit le « data » du json
+     *
+     * @param Utilisateur\UtilisateurEntite $entite Utilisateur
+     *
+     * @return array
+     */
+    private function buildData(Utilisateur\UtilisateurEntite $entite)
+    {
+        return [
+            'id' => $entite->getId(),
+            'login' => $entite->getLogin(),
+            'nom' => $entite->getNom(),
+            'prenom' => $entite->getPrenom(),
+            'is_responsable' => $entite->isResponsable(),
+            'is_haut_responsable' => $entite->isHautResponsable(),
+            'is_actif' => $entite->isActif(),
+            'quotite' => $entite->getQuotite(),
+            'mail' => $entite->getMail(),
+            'numero_exercice' => $entite->getNumeroExercice(),
+            'planning_id' => $entite->getPlanningId(),
+            'heure_solde' => $entite->getHeureSolde(),
+            'date_inscription' => $entite->getDateInscription(),
+            // mettre le lien du planning associé, sous un offset formalisé
+        ];
+    }
+}

--- a/Tools/Controllers/UtilisateurEmployeController.php
+++ b/Tools/Controllers/UtilisateurEmployeController.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\ResponseInterface as IResponse;
 use \Slim\Interfaces\RouterInterface as IRouter;
 use LibertAPI\Utilisateur;
 use LibertAPI\Tools\Exceptions\UnknownResourceException;
-
+use Doctrine\ORM\EntityManager;
 
 /**
  * Contrôleur d'utilisateurs
@@ -22,18 +22,14 @@ use LibertAPI\Tools\Exceptions\UnknownResourceException;
  */
 final class UtilisateurEmployeController extends \LibertAPI\Tools\Libraries\AController
 {
-    public function __construct(Utilisateur\UtilisateurRepository $repository, IRouter $router)
+    public function __construct(Utilisateur\UtilisateurRepository $repository, IRouter $router, EntityManager $entityManager)
     {
-        parent::__construct($repository, $router);
+        parent::__construct($repository, $router, $entityManager);
     }
 
     /*************************************************
      * GET
      *************************************************/
-
-    /* Mettre le niveau de droits autorisés
-        && ce que ces droits permettre de voir (l'utilisateur peut-il voir HR / admin ?)
-     */
 
      /**
       * {@inheritDoc}

--- a/Tools/Middlewares/AccessChecker.php
+++ b/Tools/Middlewares/AccessChecker.php
@@ -28,7 +28,6 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
             case 'HelloWorld':
             case 'Journal':
             case 'Planning|Creneau':
-            case 'Utilisateur':
                 return $next($request, $response);
             case 'Groupe':
             case 'Groupe|Employe':
@@ -45,6 +44,7 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
 
                 return $next($request, $response);
             case 'JourFerie':
+            case 'Utilisateur':
                 $user = $request->getAttribute('currentUser');
                 if (!$user->isHautResponsable()) {
                     return call_user_func(

--- a/Tools/Middlewares/AccessChecker.php
+++ b/Tools/Middlewares/AccessChecker.php
@@ -21,6 +21,7 @@ final class AccessChecker extends \LibertAPI\Tools\AMiddleware
             case 'Absence|Periode':
             case 'Absence|Type':
             case 'Authentification':
+            case 'Employe|Me':
             case 'Employe|Me|Heure|Repos':
             case 'Employe|Me|Heure|Additionnelle':
             case 'Employe|Me|Solde':

--- a/Tools/Route/Utilisateur.php
+++ b/Tools/Route/Utilisateur.php
@@ -22,4 +22,4 @@ $app->group('/utilisateur', function () {
     $this->get('', [UtilisateurController::class, 'get'])->setName('getUtilisateurListe');
 });
 
-$app->get('/employe/me', [UtilisateurEmployeController::class, 'get'])->setName('getUtilisateurDetail');
+$app->get('/employe/me', [UtilisateurEmployeController::class, 'get'])->setName('getEmployeMeDetail');

--- a/Tools/Route/Utilisateur.php
+++ b/Tools/Route/Utilisateur.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types = 1);
 
 use LibertAPI\Tools\Controllers\UtilisateurController;
+use LibertAPI\Tools\Controllers\UtilisateurEmployeController;
 
 /*
  * Doit être importé après la création de $app. Ne créé rien.
@@ -9,12 +10,7 @@ use LibertAPI\Tools\Controllers\UtilisateurController;
  */
 
 /* Routes sur l'utilisateur et associés */
-$app->group('/utilisateur', function () {
-    $this->group('/{utilisateurId:[0-9]+}', function () {
-        /* Detail */
-        $this->get('', [UtilisateurController::class, 'get'])->setName('getUtilisateurDetail');
-    });
 
-    /* Collection */
-    $this->get('', [UtilisateurController::class, 'get'])->setName('getUtilisateurListe');
-});
+$app->get('/utilisateur', [UtilisateurController::class, 'get'])->setName('getUtilisateurListe');
+
+$app->get('/employe/me', [UtilisateurEmployeController::class, 'get'])->setName('getUtilisateurListe');

--- a/Tools/Route/Utilisateur.php
+++ b/Tools/Route/Utilisateur.php
@@ -11,6 +11,15 @@ use LibertAPI\Tools\Controllers\UtilisateurEmployeController;
 
 /* Routes sur l'utilisateur et associés */
 
-$app->get('/utilisateur', [UtilisateurController::class, 'get'])->setName('getUtilisateurListe');
+$app->group('/utilisateur', function () {
+    // DEPRECATED depuis 1.10. Remplacé par /employe/me
+    $this->group('/{utilisateurId:[0-9]+}', function () {
+        /* Detail */
+        $this->get('', [UtilisateurController::class, 'get'])->setName('getUtilisateurDetail');
+    });
 
-$app->get('/employe/me', [UtilisateurEmployeController::class, 'get'])->setName('getUtilisateurListe');
+    /* Collection */
+    $this->get('', [UtilisateurController::class, 'get'])->setName('getUtilisateurListe');
+});
+
+$app->get('/employe/me', [UtilisateurEmployeController::class, 'get'])->setName('getUtilisateurDetail');

--- a/Utilisateur/UtilisateurRepository.php
+++ b/Utilisateur/UtilisateurRepository.php
@@ -41,8 +41,11 @@ class UtilisateurRepository extends \LibertAPI\Tools\Libraries\ARepository
 
     public function getOne($id) : AEntite
     {
+        // @TODO: supprimer cette ligne quand on passera à DBAL > 2.6 : https://github.com/doctrine/dbal/commit/e937f37a8acc117047ff4ed9aec493a1e3de2195
+        $this->queryBuilder->resetQueryParts();
         $this->queryBuilder->select('*, u_login AS id');
-        $this->setWhere(['id' => $id]);
+        $this->setWhere(['u_login' => $id]);
+        $this->queryBuilder->from($this->getTableName(), 'current');
         $res = $this->queryBuilder->execute();
 
         $data = $res->fetch(\PDO::FETCH_ASSOC);


### PR DESCRIPTION
Pour obtenir les informations de l'utilisateur courant il faut désormais utiliser la route `/employe/me`.

Pour tester, il suffit de s'assurer que la requête `/employe/me` retourne bien les informations de l'utilisateur courant uniquement.