### PR TITLE
"Types absences" désactivable

### DIFF
--- a/Absence/Type/Entite.php
+++ b/Absence/Type/Entite.php
@@ -49,6 +49,12 @@ class Entite
      */
     private $typeNatif;
 
+    /**
+     * @var bool
+     *
+     * @ORM\Column(name="type_natif", type="boolean", nullable=false)
+     */
+    private $typeActif;
 
     /**
      * Get id.
@@ -154,5 +160,29 @@ class Entite
     public function isTypeNatif() : bool
     {
         return (bool) $this->typeNatif;
+    }
+
+    /**
+     * Set typeActif.
+     *
+     * @param bool $typeActif
+     *
+     * @return Entite
+     */
+    public function setTypeActif(bool $typeActif)
+    {
+        $this->typeActif = $typeActif;
+
+        return $this;
+    }
+
+    /**
+     * Get typeActif.
+     *
+     * @return bool
+     */
+    public function isTypeActif() : bool
+    {
+        return (bool) $this->typeActif;
     }
 }

--- a/Absence/Type/Entite.php
+++ b/Absence/Type/Entite.php
@@ -52,7 +52,7 @@ class Entite
     /**
      * @var bool
      *
-     * @ORM\Column(name="type_natif", type="boolean", nullable=false)
+     * @ORM\Column(name="type_actif", type="boolean", nullable=false)
      */
     private $typeActif;
 

--- a/Absence/Type/TypeEntite.php
+++ b/Absence/Type/TypeEntite.php
@@ -53,6 +53,15 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
         return $this->dataUpdated['typeNatif'] ?? $this->data['typeNatif'] ?? false;
     }
 
+
+    /**
+     * Retourne la donnée la plus à jour du champ type actif
+     */
+    public function isTypeActif() : bool
+    {
+        return $this->getFreshData('typeActif');
+    }
+
     /**
      * @inheritDoc
      */

--- a/Absence/Type/TypeEntite.php
+++ b/Absence/Type/TypeEntite.php
@@ -59,7 +59,7 @@ class TypeEntite extends \LibertAPI\Tools\Libraries\AEntite
      */
     public function isTypeActif() : bool
     {
-        return $this->getFreshData('typeActif');
+        return $this->dataUpdated['typeActif'] ?? $this->data['typeAtif'] ?? true;
     }
 
     /**

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -39,7 +39,7 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
             'libelle' => $dataStorage['ta_libelle'],
             'libelleCourt' => $dataStorage['ta_short_libelle'],
             'typeNatif' => (bool) $dataStorage['type_natif'],
-            'typeActif' => (bool) $dataStorage['type_actif'],
+            'typeActif' => (bool) $dataStorage['ta_actif'],
         ];
     }
 

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -85,7 +85,7 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
             'libelle' => $entite->getLibelle(),
             'libelleCourt' => $entite->getLibelleCourt(),
             'typeNatif' => $entite->isTypeNatif(),
-            'typeactif' => $entite->isTypeActif(),
+            'typeActif' => $entite->isTypeActif(),
         ];
     }
 

--- a/Absence/Type/TypeRepository.php
+++ b/Absence/Type/TypeRepository.php
@@ -39,6 +39,7 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
             'libelle' => $dataStorage['ta_libelle'],
             'libelleCourt' => $dataStorage['ta_short_libelle'],
             'typeNatif' => (bool) $dataStorage['type_natif'],
+            'typeActif' => (bool) $dataStorage['type_actif'],
         ];
     }
 
@@ -84,6 +85,7 @@ class TypeRepository extends \LibertAPI\Tools\Libraries\ARepository
             'libelle' => $entite->getLibelle(),
             'libelleCourt' => $entite->getLibelleCourt(),
             'typeNatif' => $entite->isTypeNatif(),
+            'typeactif' => $entite->isTypeActif(),
         ];
     }
 

--- a/Tests/Units/Absence/Type/TypeRepository.php
+++ b/Tests/Units/Absence/Type/TypeRepository.php
@@ -19,6 +19,7 @@ final class TypeRepository extends \LibertAPI\Tests\Units\Tools\Libraries\ARepos
             'ta_libelle' => 'libelle',
             'ta_short_libelle' => 'li',
             'type_natif' => 1,
+            'ta_actif' => 1,
         ];
     }
 

--- a/Tools/Controllers/AbsenceTypeController.php
+++ b/Tools/Controllers/AbsenceTypeController.php
@@ -101,6 +101,7 @@ implements Interfaces\IGetable, Interfaces\IPostable, Interfaces\IPutable, Inter
             'libelle' => $entite->getLibelle(),
             'libelleCourt' => $entite->getLibelleCourt(),
             'typeNatif' => $entite->isTypeNatif(),
+            'typeActif' => $entite->isTypeActif(),
         ];
     }
 


### PR DESCRIPTION
La prochaine version de Libertempo permettra de désactiver les types d'absences... Ce PR permet de retourner la valeur du champ ta_actif par /absence/type.